### PR TITLE
primaryNumber fix

### DIFF
--- a/mlbStatsAPI/person.py
+++ b/mlbStatsAPI/person.py
@@ -284,7 +284,7 @@ class Person:
         )
 
 
-        self._primaryNumber = prsn['primaryNumber']
+        self._primaryNumber = prsn.get('primaryNumber', -1)
         self._currentAge = prsn['currentAge']
 
         self.birthDate = prsn.get('birthDate','')
@@ -568,7 +568,10 @@ class Person:
 
     @property
     def number(self) -> int:
-        """Players jersey number"""
+        """Players jersey number
+
+        If no primaryNumber was found -1 is returned.
+        """
         return self._primaryNumber
 
     @property


### PR DESCRIPTION
Fixes the case when a player does not have a primaryNumber returned from the mlb api. Replaces with a -1 to indicate no primary number present