### PR TITLE
Add season attribute to Venue #170

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To get started with the library, refer to the information provided in this READM
 
 ## Installation
 ```python
-python3 -m pip install python-mlb-statsapi==0.5.2
+python3 -m pip install python-mlb-statsapi==0.5.4
 ```
 ## Usage
 ```python

--- a/mlbstatsapi/models/venues/venue.py
+++ b/mlbstatsapi/models/venues/venue.py
@@ -23,6 +23,8 @@ class Venue:
         Info on this venue's field
     active : bool
         Is this field currently active
+    season : str
+        This field holds the season
     """
     id:         int
     link:       str
@@ -31,6 +33,7 @@ class Venue:
     timezone:   Optional[Union[TimeZone, dict]] = None
     fieldinfo:  Optional[Union[FieldInfo, dict]] = None
     active:     Optional[bool] = None
+    season:     Optional[str] = None
 
     def __post_init__(self):
         self.location = Location(**self.location) if self.location else self.location

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-mlb-statsapi"
-version = "0.5.3"
+version = "0.5.2"
 
 authors = [
   { name="Matthew Spah", email="spahmatthew@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-mlb-statsapi"
-version = "0.5.2"
+version = "0.5.4"
 
 authors = [
   { name="Matthew Spah", email="spahmatthew@gmail.com" },


### PR DESCRIPTION
### Why

MLB REST API must have updated the venue model to include an additional attribute, season. Our periodic run of our pytest suit rose an exception and alerted us to this issue.

### What

Adds season attribute field to venue object. This fixes issue https://github.com/zero-sum-seattle/python-mlb-statsapi/issues/170 Venue is receiving a unexpected keyword argument

### Tests

Ran with test suite, external and mock tests pass

### Risk and impact

- Minimal