### PR TITLE
feat(stats): add pickoffattempts to SimpleCatchingSplit model

### DIFF
--- a/mlbstatsapi/models/stats/catching.py
+++ b/mlbstatsapi/models/stats/catching.py
@@ -98,6 +98,7 @@ class SimpleCatchingSplit:
     sacbunts: Optional[int] = None
     sacflies: Optional[int] = None
     passedball: Optional[int] = None
+    pickoffattempts: Optional[int] = None
 
     def __repr__(self) -> str:
         kws = [f'{key}={value}' for key, value in self.__dict__.items() if value is not None]

--- a/tests/external_tests/team/test_team.py
+++ b/tests/external_tests/team/test_team.py
@@ -30,7 +30,7 @@ class TestTeam(unittest.TestCase):
         # Team object should have attrs set
         self.assertEqual(self.team.id, 133)
         self.assertIsInstance(self.team, Team)
-        self.assertEqual(self.team.name, "Oakland Athletics")
+        self.assertEqual(self.team.name, "Athletics")
         self.assertEqual(self.team.link, "/api/v1/teams/133")
         self.assertIsInstance(self.team.sport, Sport)
         self.assertIsInstance(self.team.venue, Venue)


### PR DESCRIPTION
- Added `pickoffattempts` as an optional attribute in the `SimpleCatchingSplit` model to enhance coverage of catching statistics.
- Updated team name assertion in `TestTeam` to ensure consistency with API responses.
