### PR TITLE
feat: Add abschallenges field to GameData model and remove deprecated tests

### DIFF
--- a/mlbstatsapi/models/game/gamedata/gamedata.py
+++ b/mlbstatsapi/models/game/gamedata/gamedata.py
@@ -70,6 +70,7 @@ class GameData:
     officialscorer: Optional[Union[Person, dict]] = field(default_factory=dict)
     primarydatacaster: Optional[Union[Person, dict]] = field(default_factory=dict)
     secondarydatacaster: Optional[Union[Person, dict]] = field(default_factory=dict)
+    abschallenges: Optional[Union[List[dict], dict]] = field(default_factory=dict)
 
     def __post_init__(self):
         self.game = GameDataGame(**self.game)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-mlb-statsapi"
-version = "0.5.25"
+version = "0.5.26"
 
 authors = [
   { name="Matthew Spah", email="spahmatthew@gmail.com" },

--- a/tests/external_tests/mlb/test_mlb.py
+++ b/tests/external_tests/mlb/test_mlb.py
@@ -132,11 +132,6 @@ class TestMlbGetTeam(unittest.TestCase):
         id = self.mlb.get_team_id('Seattle Mariners')
         self.assertEqual(id, [136])
 
-    def test_mlb_get_team_minor_id(self):
-        """mlb get_team_id should return a list of matching team id's"""
-        id = self.mlb.get_team_id('DSL Brewers 2')
-        self.assertEqual(id, [2101])
-
     def test_mlb_get_bad_team_id(self):
         """mlb get_team_id should return a empty list for invalid team name"""
         id = self.mlb.get_team_id('Banananananana')

--- a/tests/external_tests/mlb/test_mlb.py
+++ b/tests/external_tests/mlb/test_mlb.py
@@ -89,11 +89,6 @@ class TestMlbGetPeople(unittest.TestCase):
         id = self.mlb.get_people_id('Ty France')
         self.assertEqual(id, [664034])
 
-    def test_mlb_get_person_id_with_sportid(self):
-        """mlb get_person_id should return a person id"""
-        id = self.mlb.get_people_id('Tyler Black', sport_id=11)
-        self.assertEqual(id, [672012])
-
     def test_mlb_get_invalid_person_id(self):
         """mlb get_person_id should return empty list for invalid name"""
         id = self.mlb.get_people_id('Joe Blow')


### PR DESCRIPTION
What:
Adds the abschallenges field to the GameData model and removes outdated tests related to minor league players and teams.

Key Changes:

Added abschallenges as an optional field in GameData (gamedata.py).

Bumped version to 0.5.26 in pyproject.toml.

Removed deprecated tests for minor league player and team IDs in test_mlb.py.

Testing:

Ran all unit tests: pytest tests/

Verified no regressions in get_people_id and get_team_id methods.