### PR TITLE
add alias for strikeout stats

### DIFF
--- a/mlbstatsapi/models/stats/catching.py
+++ b/mlbstatsapi/models/stats/catching.py
@@ -79,7 +79,7 @@ class SimpleCatchingSplit(MLBBaseModel):
     games_played: Optional[int] = Field(default=None, alias="gamesPlayed")
     runs: Optional[int] = None
     home_runs: Optional[int] = Field(default=None, alias="homeRuns")
-    strikeouts: Optional[int] = None
+    strikeouts: Optional[int] = Field(default=None, alias="strikeOuts")
     base_on_balls: Optional[int] = Field(default=None, alias="baseOnBalls")
     intentional_walks: Optional[int] = Field(default=None, alias="intentionalWalks")
     hits: Optional[int] = None

--- a/mlbstatsapi/models/stats/hitting.py
+++ b/mlbstatsapi/models/stats/hitting.py
@@ -198,7 +198,7 @@ class SimpleHittingSplit(MLBBaseModel):
     doubles: Optional[int] = None
     triples: Optional[int] = None
     home_runs: Optional[int] = Field(default=None, alias="homeRuns")
-    strikeouts: Optional[int] = None
+    strikeouts: Optional[int] = Field(default=None, alias="strikeOuts")
     base_on_balls: Optional[int] = Field(default=None, alias="baseOnBalls")
     intentional_walks: Optional[int] = Field(default=None, alias="intentionalWalks")
     hits: Optional[int] = None

--- a/mlbstatsapi/models/stats/pitching.py
+++ b/mlbstatsapi/models/stats/pitching.py
@@ -155,7 +155,7 @@ class SimplePitchingSplit(MLBBaseModel):
     doubles: Optional[int] = None
     triples: Optional[int] = None
     home_runs: Optional[int] = Field(default=None, alias="homeRuns")
-    strikeouts: Optional[int] = None
+    strikeouts: Optional[int] = Field(default=None, alias="strikeOuts")
     base_on_balls: Optional[int] = Field(default=None, alias="baseOnBalls")
     intentional_walks: Optional[int] = Field(default=None, alias="intentionalWalks")
     hits: Optional[int] = None


### PR DESCRIPTION
strikeout data is not populating

The MLB api represents the data as camel case `strikeOuts` and in the models it is one word `strikeouts` preventing it from auto populating.
 
I added an alias to strikeouts in the hitting, pitching, and catching models so it populates.

Passes all unit tests.