### PR TITLE
Fix GameData absChallenges model

### DIFF
--- a/mlbstatsapi/models/game/gamedata/attributes.py
+++ b/mlbstatsapi/models/game/gamedata/attributes.py
@@ -200,6 +200,42 @@ class GameReview(MLBBaseModel):
     home: ReviewInfo
 
 
+class AbsChallengeInfo(MLBBaseModel):
+    """
+    A class to represent ABS challenge info for each team in this game.
+
+    Attributes
+    ----------
+    used_successful : int
+        How many successful ABS challenges were used.
+    used_failed : int
+        How many failed ABS challenges were used.
+    remaining : int
+        How many ABS challenges are remaining.
+    """
+    used_successful: int = Field(alias="usedSuccessful")
+    used_failed: int = Field(alias="usedFailed")
+    remaining: int
+
+
+class AbsChallenges(MLBBaseModel):
+    """
+    A class to represent ABS challenge information for this game.
+
+    Attributes
+    ----------
+    has_challenges : bool
+        If ABS challenges are available.
+    away : AbsChallengeInfo
+        Away team ABS challenge info.
+    home : AbsChallengeInfo
+        Home team ABS challenge info.
+    """
+    has_challenges: bool = Field(alias="hasChallenges")
+    away: AbsChallengeInfo
+    home: AbsChallengeInfo
+
+
 class GameFlags(MLBBaseModel):
     """
     A class to represent the flags for this game.

--- a/mlbstatsapi/models/game/gamedata/gamedata.py
+++ b/mlbstatsapi/models/game/gamedata/gamedata.py
@@ -11,6 +11,7 @@ from .attributes import (
     GameWeather,
     GameInfo,
     GameReview,
+    AbsChallenges,
     GameFlags,
     GameProbablePitchers,
     MoundVisits,
@@ -57,8 +58,8 @@ class GameData(MLBBaseModel):
         Secondary data caster for this game.
     mound_visits : MoundVisits
         Mound visits for this game.
-    abs_challenges : List[dict]
-        ABS challenges for this game.
+    abs_challenges : AbsChallenges
+        ABS challenge information for this game.
     """
     game: GameDataGame
     datetime: GameDatetime
@@ -77,7 +78,7 @@ class GameData(MLBBaseModel):
     official_scorer: Optional[Person] = Field(default=None, alias="officialScorer")
     primary_data_caster: Optional[Person] = Field(default=None, alias="primaryDataCaster")
     secondary_data_caster: Optional[Person] = Field(default=None, alias="secondaryDataCaster")
-    abs_challenges: Optional[List[dict]] = Field(default=None, alias="absChallenges")
+    abs_challenges: Optional[AbsChallenges] = Field(default=None, alias="absChallenges")
 
     @model_validator(mode='before')
     @classmethod


### PR DESCRIPTION
Fix GameData absChallenges validation

``` markdown
## Summary

Fixes `GameData.absChallenges` parsing for MLB API responses where `absChallenges` is returned as an object containing ABS-specific challenge fields.

## Why

Some game feed responses return `gameData.absChallenges` as:

- a single object, not a list
- nested team challenge info using `usedSuccessful`, `usedFailed`, and `remaining`

This caused Pydantic validation errors when calling `get_game()` for affected games.

## What

- Added ABS-specific models for `absChallenges`
- Updated `GameData.abs_challenges` to use the new ABS challenge model
- Updated the `GameData` docstring to reflect the correct field type

## Tests

Verified that `mlb.get_game(822974)` now parses successfully and exposes ABS challenge data through:

- `game.game_data.abs_challenges.away.used_successful`
- `game.game_data.abs_challenges.away.used_failed`
- `game.game_data.abs_challenges.away.remaining`

existing tests were all executed & pass.

Note: I checked `development`, but `Mlb.get_game()` does not exist on that branch. This validation issue occurs in the current `main` implementation of `get_game()`, so this PR targets `main`.

### Risk and impact

Risk level: Minimal

This change is limited to the `GameData.absChallenges` model parsing. It adds a more accurate model for the ABS challenge payload returned by the MLB API and updates `GameData.abs_challenges` to use that model instead of a generic list/dict shape.

The main risk is that if the MLB API returns another unexpected `absChallenges` shape, parsing could still fail for affected games. If something goes wrong, impact should be limited to `get_game()` responses that include `gameData.absChallenges`; unrelated endpoints and non-ABS game data should be unaffected.
```


