### PR TITLE
fix: correct HTTP adapter response handling

### DIFF
--- a/mlbstatsapi/mlb_dataadapter.py
+++ b/mlbstatsapi/mlb_dataadapter.py
@@ -18,13 +18,18 @@ class MlbResult:
         JSON Data received from request
     """
 
-    def __init__(self, status_code: int, message: str, data: Dict = {}):
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        data: Dict | None = None,
+    ):
         self.status_code = int(status_code)
         self.message = str(message)
 
-        self.data = data
-        if 'copyright' in data:
-            del data['copyright']
+        # Copy so caller-owned dictionaries are not mutated when copyright is removed.
+        self.data = dict(data) if data is not None else {}
+        self.data.pop("copyright", None)
 
 
 class MlbDataAdapter:
@@ -44,7 +49,6 @@ class MlbDataAdapter:
     def __init__(self, hostname: str = 'statsapi.mlb.com', ver: str = 'v1', logger: logging.Logger = None):
         self.url = f'https://{hostname}/api/{ver}/'
         self._logger = logger or logging.getLogger(__name__)
-        self._logger.setLevel(logging.DEBUG)
 
     def get(self, endpoint: str, ep_params: Dict = None, data: Dict = None) -> MlbResult:
         """
@@ -76,32 +80,57 @@ class MlbDataAdapter:
             self._logger.error(msg=(str(e)))
             raise TheMlbStatsApiException('Request failed') from e
 
-        try:
-            data = response.json()
+        status_code = response.status_code
 
-        except (ValueError, requests.JSONDecodeError) as e: 
-            self._logger.error(msg=(str(e)))
-            raise TheMlbStatsApiException('Bad JSON in response') from e
+        if 400 <= status_code <= 499:
+            self._logger.error(msg=logline_post.format(
+                'Invalid Request',
+                status_code,
+                response.reason,
+                response.url,
+            ))
+            return MlbResult(
+                status_code=status_code,
+                message=response.reason,
+                data={},
+            )
 
-        if response.status_code <= 200 and response.status_code <= 299:
-            self._logger.debug(msg=logline_post.format('success',
-            response.status_code, response.reason, response.url))
+        if 500 <= status_code <= 599:
+            self._logger.error(msg=logline_post.format(
+                'Internal error occurred',
+                status_code,
+                response.reason,
+                response.url,
+            ))
+            raise TheMlbStatsApiException(
+                f"{status_code}: {response.reason}"
+            )
 
-            return MlbResult(response.status_code, message=response.reason, data=data)
+        if not 200 <= status_code <= 299:
+            raise TheMlbStatsApiException(
+                f"{status_code}: {response.reason}"
+            )
 
-        elif response.status_code >= 400 and response.status_code <= 499:  
-            self._logger.error(msg=logline_post.format('Invalid Request',
-            response.status_code, response.reason, response.url))
+        self._logger.debug(msg=logline_post.format(
+            'success',
+            status_code,
+            response.reason,
+            response.url,
+        ))
 
-            # return MlbResult with 404 and empty data
-            return MlbResult(response.status_code, message=response.reason, data={})
-
-        elif response.status_code >= 500 and response.status_code <= 599:
-
-            self._logger.error(msg=logline_post.format('Internal error occurred', 
-            response.status_code, response.reason, response.url))
-
-            raise TheMlbStatsApiException(f"{response.status_code}: {response.reason}")
-
+        if not response.content:
+            response_data = {}
         else:
-            raise TheMlbStatsApiException(f"{response.status_code}: {response.reason}")
+            try:
+                response_data = response.json()
+            except (ValueError, requests.JSONDecodeError) as exc:
+                self._logger.error(msg=(str(exc)))
+                raise TheMlbStatsApiException(
+                    "Bad JSON in response"
+                ) from exc
+
+        return MlbResult(
+            status_code,
+            message=response.reason,
+            data=response_data,
+        )

--- a/tests/test_mlb_dataadapter.py
+++ b/tests/test_mlb_dataadapter.py
@@ -1,9 +1,11 @@
-"""Offline characterization tests for MlbDataAdapter.
+"""Offline regression tests for MlbDataAdapter.
 
-These tests document current HTTP adapter behavior with requests-mock before
-the transport is refactored in version 0.8.0. Known defects use strict xfail
-markers so a future fix causes XPASS until the marker is removed.
+These tests protect HTTP adapter response-handling behavior for version 0.8.0,
+including successful 2xx handling, status classification before JSON decoding,
+and empty successful bodies.
 """
+
+import logging
 
 import requests
 import pytest
@@ -36,6 +38,49 @@ def test_successful_json_response_returns_exact_values(adapter, requests_mock):
     assert result.status_code == 200
     assert result.message == "OK"
     assert result.data == {"sports": [{"id": 1, "name": "Major League Baseball"}]}
+
+
+@pytest.mark.parametrize(
+    ("status_code", "reason", "payload"),
+    [
+        (201, "Created", {"id": 42, "name": "created"}),
+        (299, "Custom Success", {"ok": True}),
+    ],
+)
+def test_other_successful_json_statuses_return_exact_values(
+    adapter,
+    requests_mock,
+    status_code,
+    reason,
+    payload,
+):
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        json=payload,
+        status_code=status_code,
+        reason=reason,
+    )
+
+    result = adapter.get(endpoint="sports")
+
+    assert result.status_code == status_code
+    assert result.message == reason
+    assert result.data == payload
+
+
+def test_empty_successful_response_returns_empty_data(adapter, requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        text="",
+        status_code=204,
+        reason="No Content",
+    )
+
+    result = adapter.get(endpoint="sports")
+
+    assert result.status_code == 204
+    assert result.message == "No Content"
+    assert result.data == {}
 
 
 def test_ep_params_are_sent_as_query_parameters(adapter, requests_mock):
@@ -107,6 +152,23 @@ def test_json_404_returns_empty_data(adapter, requests_mock):
     result = adapter.get(endpoint="teams/19990")
 
     assert result.status_code == 404
+    assert result.message == "Not Found"
+    assert result.data == {}
+
+
+def test_non_json_404_returns_empty_data(adapter, requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}teams/19990",
+        text="<html><body>Not Found</body></html>",
+        status_code=404,
+        reason="Not Found",
+        headers={"Content-Type": "text/html"},
+    )
+
+    result = adapter.get(endpoint="teams/19990")
+
+    assert result.status_code == 404
+    assert result.message == "Not Found"
     assert result.data == {}
 
 
@@ -130,6 +192,21 @@ def test_json_500_raises_the_mlb_stats_api_exception(adapter, requests_mock):
         )
 
     assert str(exc_info.value) == "500: Internal Server Error"
+
+
+def test_html_502_raises_the_mlb_stats_api_exception(adapter, requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        text="<html><body>Bad Gateway</body></html>",
+        status_code=502,
+        reason="Bad Gateway",
+        headers={"Content-Type": "text/html"},
+    )
+
+    with pytest.raises(TheMlbStatsApiException, match=r"^502: Bad Gateway$") as exc_info:
+        adapter.get(endpoint="sports")
+
+    assert str(exc_info.value) == "502: Bad Gateway"
 
 
 def test_connection_failure_raises_request_failed(adapter, requests_mock):
@@ -163,6 +240,17 @@ def test_invalid_json_on_successful_response_raises_bad_json(adapter, requests_m
     assert str(exc_info.value) == "Bad JSON in response"
 
 
+def test_constructor_does_not_change_logger_level():
+    logger = logging.Logger(
+        "mlbstatsapi-test",
+        level=logging.WARNING,
+    )
+
+    MlbDataAdapter(logger=logger)
+
+    assert logger.level == logging.WARNING
+
+
 def test_mlb_result_optional_data_argument_omitted():
     result = MlbResult(200, "OK")
 
@@ -184,46 +272,3 @@ def test_mlb_result_type_coercion():
 
     assert result.status_code == 200
     assert result.message == "123"
-
-
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Adapter always JSON-decodes before status handling; "
-        "fix/http-adapter-correctness should return empty data for empty successful bodies"
-    ),
-)
-def test_empty_successful_response_returns_empty_data(adapter, requests_mock):
-    requests_mock.get(
-        f"{BASE_URL}sports",
-        text="",
-        status_code=204,
-        reason="No Content",
-    )
-
-    result = adapter.get(endpoint="sports")
-
-    assert result.status_code == 204
-    assert result.data == {}
-
-
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Adapter JSON-decodes before HTTP status handling; "
-        "fix/http-adapter-correctness should return empty data for non-JSON 404 bodies"
-    ),
-)
-def test_non_json_404_returns_empty_data(adapter, requests_mock):
-    requests_mock.get(
-        f"{BASE_URL}teams/19990",
-        text="<html><body>Not Found</body></html>",
-        status_code=404,
-        reason="Not Found",
-        headers={"Content-Type": "text/html"},
-    )
-
-    result = adapter.get(endpoint="teams/19990")
-
-    assert result.status_code == 404
-    assert result.data == {}

--- a/tests/test_mlb_result.py
+++ b/tests/test_mlb_result.py
@@ -1,10 +1,8 @@
-"""Offline characterization tests for MlbResult.
+"""Offline regression tests for MlbResult.
 
-These tests document current constructor behavior before the HTTP adapter
-correctness work in version 0.8.0. Known defects use strict xfail markers.
+These tests protect MlbResult constructor behavior for version 0.8.0,
+including independent data dictionaries and caller-owned dictionary safety.
 """
-
-import pytest
 
 from mlbstatsapi import MlbResult
 
@@ -68,33 +66,28 @@ def test_accepts_explicitly_supplied_dictionary():
     assert result.data == {"teams": [{"id": 133}]}
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "MlbResult uses a shared mutable default for data; "
-        "fix/http-adapter-correctness should give each instance its own dict"
-    ),
-)
 def test_each_instance_gets_independent_data_dict():
     first = MlbResult(200, "OK")
     second = MlbResult(200, "OK")
 
+    first.data["changed"] = True
+
+    assert second.data == {}
     assert first.data is not second.data
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "MlbResult deletes copyright from the caller-owned dictionary; "
-        "fix/http-adapter-correctness should leave the input unchanged"
-    ),
-)
 def test_does_not_mutate_caller_owned_dictionary():
     payload = {
         "copyright": "MLB",
         "sports": [],
     }
 
-    MlbResult(200, "OK", payload)
+    result = MlbResult(200, "OK", payload)
 
-    assert "copyright" in payload
+    assert payload == {
+        "copyright": "MLB",
+        "sports": [],
+    }
+    assert result.data == {
+        "sports": [],
+    }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Correct HTTP adapter response-handling defects before sessions, timeouts, retries, or structured exception subclasses are introduced.

### Why status classification now occurs before JSON decoding

Error responses from MLB (and intermediate proxies) may return HTML or other non-JSON bodies. Decoding before checking status incorrectly raised `Bad JSON in response` for 4xx/5xx failures. The adapter now classifies by HTTP status first, so a JSON or HTML 404 still returns empty data, and a JSON or HTML 5xx raises the HTTP-status exception.

### How the full 2xx range is handled

Successful responses are now detected with `200 <= status_code <= 299`, so statuses such as 201, 204, and 299 are accepted instead of falling through to the non-2xx fallback.

### How empty successful responses are handled

After a successful status check, an empty body uses `response_data = {}`. Non-empty successful bodies are decoded as JSON once; invalid JSON still raises `TheMlbStatsApiException("Bad JSON in response")` with exception chaining.

### How `MlbResult` now protects caller-owned data

`MlbResult` no longer uses a mutable default dictionary. Each instance gets a new outer dictionary (`dict(data)` or `{}`), and `copyright` is removed only from that copy. Caller-owned dictionaries are left unchanged.

### Compatibility

- 404 responses still return `MlbResult(status_code=404, message=response.reason, data={})`
- 5xx responses still raise `TheMlbStatsApiException` with `"{status}: {reason}"`
- No sessions, retries, timeouts, or new exception subclasses were added
- Constructor and `get()` signatures are unchanged, including the unused `data` argument

## Test plan

Focused adapter/result tests:

```bash
poetry run pytest \
  tests/test_mlb_dataadapter.py \
  tests/test_mlb_result.py \
  -v
```

Result: **26 passed**, 0 failed, 0 xfailed, 0 xpassed

Complete offline suite:

```bash
poetry run pytest tests/ --ignore=tests/external_tests
```

Result: **95 passed**

Live adapter tests:

```bash
poetry run pytest \
  tests/external_tests/mlbdataadapter/test_mlbadapter.py \
  -v
```

Result: **3 passed** (live MLB API was available)

### Risk and impact

- Risk: Normal — response classification and `MlbResult` ownership change, but public signatures and 404/5xx semantics are preserved
- Impact if wrong: callers could mis-handle non-200 success statuses, empty bodies, or HTML error pages; covered by the new regression tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-38c85a91-31b8-4c8f-b61a-21fd208257e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-38c85a91-31b8-4c8f-b61a-21fd208257e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

