### PR TITLE
Establish the 0.9.0 HTTP behavior contract

### DIFF
--- a/tests/http_contract_support.py
+++ b/tests/http_contract_support.py
@@ -1,0 +1,87 @@
+"""Shared offline HTTP status matrices and retry-policy assertions.
+
+These status groups document the version 0.8.0 compatibility baseline and are
+intended for reuse by later version 0.9.0 strict-mode and retry-policy tests.
+
+They must not contact the live MLB API.
+"""
+
+from __future__ import annotations
+
+from urllib3.util.retry import Retry
+
+
+# Final non-404 client errors that currently return an empty MlbResult by
+# default rather than raising MlbHttpError. Later strict-mode work should
+# reuse this matrix when asserting the opposite behavior.
+COMPATIBILITY_CLIENT_ERRORS = (
+    400,
+    401,
+    403,
+    405,
+    422,
+    429,
+)
+
+NOT_FOUND_STATUS = 404
+
+SERVER_ERRORS = (
+    500,
+    502,
+    503,
+    504,
+)
+
+# Statuses retried by the library-created Session policy.
+RETRYABLE_STATUS_CODES = (
+    429,
+    500,
+    502,
+    503,
+    504,
+)
+
+# Ordinary client errors that must not be retried. Includes 404 and the
+# non-429 compatibility client errors.
+NON_RETRYABLE_CLIENT_ERRORS = (
+    400,
+    401,
+    403,
+    404,
+    405,
+    422,
+)
+
+HTTP_REASON_BY_STATUS = {
+    400: "Bad Request",
+    401: "Unauthorized",
+    403: "Forbidden",
+    404: "Not Found",
+    405: "Method Not Allowed",
+    422: "Unprocessable Entity",
+    429: "Too Many Requests",
+    500: "Internal Server Error",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+    504: "Gateway Timeout",
+}
+
+
+def assert_library_retry_policy(retry: Retry) -> None:
+    """Assert the library-created Session retry policy values.
+
+    Kept in tests so retry and contract modules share one source of truth
+    without exposing a public production helper.
+    """
+    assert retry.total == 3
+    assert retry.connect == 3
+    assert retry.read == 2
+    assert retry.status == 3
+    assert retry.backoff_factor == 0.5
+    assert set(retry.status_forcelist) == set(RETRYABLE_STATUS_CODES)
+    assert retry.allowed_methods == frozenset({"GET"})
+    assert retry.respect_retry_after_header is True
+    assert retry.raise_on_status is False
+    assert "POST" not in retry.allowed_methods
+    assert "PATCH" not in retry.allowed_methods
+    assert "DELETE" not in retry.allowed_methods

--- a/tests/test_http_contract.py
+++ b/tests/test_http_contract.py
@@ -1,0 +1,305 @@
+"""High-level offline HTTP compatibility contract for version 0.9.0.
+
+Protects existing version 0.8.0 public behavior before configurable transport
+features are implemented. These tests intentionally validate current
+compatibility behavior only; they do not enable strict mode or add production
+features.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from mlbstatsapi import (
+    Mlb,
+    MlbDataAdapter,
+    MlbHttpError,
+    MlbResult,
+    TheMlbStatsApiException,
+)
+from mlbstatsapi.mlb_dataadapter import DEFAULT_TIMEOUT
+
+from http_contract_support import (
+    COMPATIBILITY_CLIENT_ERRORS,
+    HTTP_REASON_BY_STATUS,
+    NOT_FOUND_STATUS,
+    SERVER_ERRORS,
+    assert_library_retry_policy,
+)
+
+
+def _response(
+    *,
+    status_code: int,
+    reason: str,
+    url: str,
+    content: bytes = b"",
+    payload=None,
+):
+    response = MagicMock()
+    response.status_code = status_code
+    response.reason = reason
+    response.url = url
+    response.content = content
+    if payload is None:
+        response.json.side_effect = ValueError("no json")
+    else:
+        response.json.return_value = payload
+    return response
+
+
+class RecordingSession:
+    """Minimal session stand-in that records get() and close() calls."""
+
+    def __init__(self):
+        self.calls = []
+        self.close_calls = 0
+        self.headers = requests.structures.CaseInsensitiveDict()
+
+    def get(self, url, params=None, timeout=None, **kwargs):
+        self.calls.append(
+            {
+                "url": url,
+                "params": params,
+                "timeout": timeout,
+                "kwargs": kwargs,
+            }
+        )
+        return _response(
+            status_code=200,
+            reason="OK",
+            url=url,
+            content=b'{"sports": []}',
+            payload={"sports": []},
+        )
+
+    def close(self):
+        self.close_calls += 1
+
+
+# --- Status matrices remain available for later strict-mode work ---
+
+
+def test_status_matrices_document_compatibility_baseline():
+    assert COMPATIBILITY_CLIENT_ERRORS == (400, 401, 403, 405, 422, 429)
+    assert NOT_FOUND_STATUS == 404
+    assert SERVER_ERRORS == (500, 502, 503, 504)
+    assert 404 not in COMPATIBILITY_CLIENT_ERRORS
+    assert 429 in COMPATIBILITY_CLIENT_ERRORS
+    assert set(SERVER_ERRORS).isdisjoint(COMPATIBILITY_CLIENT_ERRORS)
+
+
+# --- Default 4xx compatibility (empty MlbResult, no MlbHttpError) ---
+
+
+@pytest.mark.parametrize("status_code", COMPATIBILITY_CLIENT_ERRORS)
+def test_compatibility_client_errors_return_empty_mlb_result(status_code):
+    reason = HTTP_REASON_BY_STATUS[status_code]
+    url = f"https://statsapi.mlb.com/api/v1/sports"
+    session = MagicMock()
+    session.get.return_value = _response(
+        status_code=status_code,
+        reason=reason,
+        url=url,
+    )
+    mlb = Mlb(session=session)
+
+    result = mlb._mlb_adapter_v1.get(endpoint="sports")
+
+    assert isinstance(result, MlbResult)
+    assert result.status_code == status_code
+    assert result.data == {}
+
+
+@pytest.mark.parametrize("status_code", COMPATIBILITY_CLIENT_ERRORS)
+def test_compatibility_client_errors_do_not_raise_mlb_http_error(status_code):
+    reason = HTTP_REASON_BY_STATUS[status_code]
+    session = MagicMock()
+    session.get.return_value = _response(
+        status_code=status_code,
+        reason=reason,
+        url="https://statsapi.mlb.com/api/v1/sports",
+    )
+    adapter = MlbDataAdapter(session=session)
+
+    result = adapter.get(endpoint="sports")
+
+    assert result.status_code == status_code
+    assert result.data == {}
+
+
+# --- Endpoint-specific 404 return shapes via public Mlb methods ---
+
+
+def test_mlb_get_person_404_returns_none():
+    session = MagicMock()
+    session.get.return_value = _response(
+        status_code=NOT_FOUND_STATUS,
+        reason=HTTP_REASON_BY_STATUS[NOT_FOUND_STATUS],
+        url="https://statsapi.mlb.com/api/v1/people/999999",
+    )
+    mlb = Mlb(session=session)
+
+    assert mlb.get_person(999999) is None
+
+
+def test_mlb_get_teams_404_returns_empty_list():
+    session = MagicMock()
+    session.get.return_value = _response(
+        status_code=NOT_FOUND_STATUS,
+        reason=HTTP_REASON_BY_STATUS[NOT_FOUND_STATUS],
+        url="https://statsapi.mlb.com/api/v1/teams",
+    )
+    mlb = Mlb(session=session)
+
+    assert mlb.get_teams() == []
+
+
+def test_mlb_get_player_stats_404_returns_empty_mapping():
+    session = MagicMock()
+    session.get.return_value = _response(
+        status_code=NOT_FOUND_STATUS,
+        reason=HTTP_REASON_BY_STATUS[NOT_FOUND_STATUS],
+        url="https://statsapi.mlb.com/api/v1/people/999999/stats",
+    )
+    mlb = Mlb(session=session)
+
+    assert mlb.get_player_stats(999999, ["season"], ["hitting"]) == {}
+
+
+def test_mlb_endpoint_404_does_not_raise_mlb_http_error():
+    session = MagicMock()
+    session.get.return_value = _response(
+        status_code=NOT_FOUND_STATUS,
+        reason=HTTP_REASON_BY_STATUS[NOT_FOUND_STATUS],
+        url="https://statsapi.mlb.com/api/v1/people/999999",
+    )
+    mlb = Mlb(session=session)
+
+    assert mlb.get_person(999999) is None
+    assert mlb.get_teams() == []
+    assert mlb.get_player_stats(999999, ["season"], ["hitting"]) == {}
+
+
+# --- Final 5xx raises MlbHttpError with existing attributes ---
+
+
+@pytest.mark.parametrize("status_code", SERVER_ERRORS)
+def test_mlb_server_errors_raise_mlb_http_error_with_existing_attributes(status_code):
+    reason = HTTP_REASON_BY_STATUS[status_code]
+    url = "https://statsapi.mlb.com/api/v1/people/664034"
+    session = MagicMock()
+    session.get.return_value = _response(
+        status_code=status_code,
+        reason=reason,
+        url=url,
+    )
+    mlb = Mlb(session=session)
+
+    with pytest.raises(MlbHttpError, match=rf"^{status_code}: {reason}$") as exc_info:
+        mlb.get_person(664034)
+
+    exc = exc_info.value
+    assert isinstance(exc, TheMlbStatsApiException)
+    assert exc.status_code == status_code
+    assert exc.reason == reason
+    assert exc.url == url
+    # Richer error context belongs to a later issue; protect the current shape.
+    assert not hasattr(exc, "response_data")
+    assert not hasattr(exc, "body_excerpt")
+
+
+# --- Library-created retry policy (contract-level guard) ---
+
+
+def test_library_created_mlb_session_retains_retry_policy_contract():
+    mlb = Mlb()
+    try:
+        for scheme in ("https://", "http://"):
+            assert_library_retry_policy(mlb._session.get_adapter(scheme).max_retries)
+    finally:
+        mlb.close()
+
+
+# --- Constructor compatibility / positional argument order ---
+
+
+def test_mlb_constructors_remain_compatible():
+    mlb_default = Mlb()
+    try:
+        assert isinstance(mlb_default._session, requests.Session)
+        assert mlb_default._timeout == DEFAULT_TIMEOUT
+    finally:
+        mlb_default.close()
+
+    mlb_host = Mlb("statsapi.mlb.com")
+    try:
+        assert mlb_host._mlb_adapter_v1.url.startswith(
+            "https://statsapi.mlb.com/api/v1/"
+        )
+    finally:
+        mlb_host.close()
+
+    logger = MagicMock()
+    logger.level = 0
+    mlb_logger = Mlb("statsapi.mlb.com", logger)
+    try:
+        assert mlb_logger._logger is logger
+    finally:
+        mlb_logger.close()
+
+
+def test_mlb_positional_timeout_remains_third_argument():
+    """Guard against inserting new positional args before timeout."""
+    session = RecordingSession()
+    mlb = Mlb("statsapi.mlb.com", None, 10, session)
+
+    mlb._mlb_adapter_v1.get(endpoint="sports")
+    mlb._mlb_adapter_v1_1.get(endpoint="game")
+
+    assert session.calls[0]["timeout"] == 10
+    assert session.calls[1]["timeout"] == 10
+    assert mlb._session is session
+
+
+def test_adapter_positional_construction_remains_compatible():
+    logger = MagicMock()
+    session = RecordingSession()
+    adapter = MlbDataAdapter("statsapi.mlb.com", "v1.1", logger, (5.0, 60.0), session)
+
+    assert adapter.url == "https://statsapi.mlb.com/api/v1.1/"
+    assert adapter._logger is logger
+    assert adapter._timeout == (5.0, 60.0)
+    assert adapter._session is session
+
+    adapter.get(endpoint="game")
+    assert session.calls[0]["timeout"] == (5.0, 60.0)
+
+
+# --- Timeout forwarding at the Mlb client level ---
+
+
+def test_mlb_timeout_constructors_forward_to_both_adapters():
+    default_session = RecordingSession()
+    mlb_default = Mlb(session=default_session)
+    mlb_default._mlb_adapter_v1.get(endpoint="sports")
+    mlb_default._mlb_adapter_v1_1.get(endpoint="game")
+    assert default_session.calls[0]["timeout"] == DEFAULT_TIMEOUT
+    assert default_session.calls[1]["timeout"] == DEFAULT_TIMEOUT
+
+    scalar_session = RecordingSession()
+    mlb_scalar = Mlb(session=scalar_session, timeout=10)
+    mlb_scalar._mlb_adapter_v1.get(endpoint="sports")
+    mlb_scalar._mlb_adapter_v1_1.get(endpoint="game")
+    assert scalar_session.calls[0]["timeout"] == 10
+    assert scalar_session.calls[1]["timeout"] == 10
+
+    tuple_session = RecordingSession()
+    mlb_tuple = Mlb(session=tuple_session, timeout=(5.0, 60.0))
+    mlb_tuple._mlb_adapter_v1.get(endpoint="sports")
+    mlb_tuple._mlb_adapter_v1_1.get(endpoint="game")
+    assert tuple_session.calls[0]["timeout"] == (5.0, 60.0)
+    assert tuple_session.calls[1]["timeout"] == (5.0, 60.0)

--- a/tests/test_http_contract.py
+++ b/tests/test_http_contract.py
@@ -216,9 +216,6 @@ def test_mlb_server_errors_raise_mlb_http_error_with_existing_attributes(status_
     assert exc.status_code == status_code
     assert exc.reason == reason
     assert exc.url == url
-    # Richer error context belongs to a later issue; protect the current shape.
-    assert not hasattr(exc, "response_data")
-    assert not hasattr(exc, "body_excerpt")
 
 
 # --- Library-created retry policy (contract-level guard) ---

--- a/tests/test_http_contract.py
+++ b/tests/test_http_contract.py
@@ -39,6 +39,7 @@ def _response(
     content: bytes = b"",
     payload=None,
 ):
+    """Build a fake requests Response for offline adapter tests."""
     response = MagicMock()
     response.status_code = status_code
     response.reason = reason
@@ -84,6 +85,7 @@ class RecordingSession:
 
 
 def test_status_matrices_document_compatibility_baseline():
+    """Keep the shared status groups stable for later strict-mode tests."""
     assert COMPATIBILITY_CLIENT_ERRORS == (400, 401, 403, 405, 422, 429)
     assert NOT_FOUND_STATUS == 404
     assert SERVER_ERRORS == (500, 502, 503, 504)
@@ -97,6 +99,7 @@ def test_status_matrices_document_compatibility_baseline():
 
 @pytest.mark.parametrize("status_code", COMPATIBILITY_CLIENT_ERRORS)
 def test_compatibility_client_errors_return_empty_mlb_result(status_code):
+    """Non-404 4xx responses return an empty MlbResult via the Mlb adapters."""
     reason = HTTP_REASON_BY_STATUS[status_code]
     url = "https://statsapi.mlb.com/api/v1/sports"
     session = MagicMock()
@@ -116,6 +119,7 @@ def test_compatibility_client_errors_return_empty_mlb_result(status_code):
 
 @pytest.mark.parametrize("status_code", COMPATIBILITY_CLIENT_ERRORS)
 def test_compatibility_client_errors_do_not_raise_mlb_http_error(status_code):
+    """Compatibility-mode client errors must not raise MlbHttpError."""
     reason = HTTP_REASON_BY_STATUS[status_code]
     session = MagicMock()
     session.get.return_value = _response(
@@ -135,6 +139,7 @@ def test_compatibility_client_errors_do_not_raise_mlb_http_error(status_code):
 
 
 def test_mlb_get_person_404_returns_none():
+    """Single-object endpoints keep returning None on 404."""
     session = MagicMock()
     session.get.return_value = _response(
         status_code=NOT_FOUND_STATUS,
@@ -147,6 +152,7 @@ def test_mlb_get_person_404_returns_none():
 
 
 def test_mlb_get_teams_404_returns_empty_list():
+    """Collection endpoints keep returning an empty list on 404."""
     session = MagicMock()
     session.get.return_value = _response(
         status_code=NOT_FOUND_STATUS,
@@ -159,6 +165,7 @@ def test_mlb_get_teams_404_returns_empty_list():
 
 
 def test_mlb_get_player_stats_404_returns_empty_mapping():
+    """Mapping endpoints keep returning an empty dict on 404."""
     session = MagicMock()
     session.get.return_value = _response(
         status_code=NOT_FOUND_STATUS,
@@ -171,6 +178,7 @@ def test_mlb_get_player_stats_404_returns_empty_mapping():
 
 
 def test_mlb_endpoint_404_does_not_raise_mlb_http_error():
+    """Public 404 handling stays domain-level empty results, not MlbHttpError."""
     session = MagicMock()
     session.get.return_value = _response(
         status_code=NOT_FOUND_STATUS,
@@ -189,6 +197,7 @@ def test_mlb_endpoint_404_does_not_raise_mlb_http_error():
 
 @pytest.mark.parametrize("status_code", SERVER_ERRORS)
 def test_mlb_server_errors_raise_mlb_http_error_with_existing_attributes(status_code):
+    """Persistent 5xx failures raise MlbHttpError with status_code, reason, and url."""
     reason = HTTP_REASON_BY_STATUS[status_code]
     url = "https://statsapi.mlb.com/api/v1/people/664034"
     session = MagicMock()
@@ -216,6 +225,7 @@ def test_mlb_server_errors_raise_mlb_http_error_with_existing_attributes(status_
 
 
 def test_library_created_mlb_session_retains_retry_policy_contract():
+    """Library-created Mlb Sessions keep the existing retry policy values."""
     mlb = Mlb()
     try:
         for scheme in ("https://", "http://"):
@@ -228,6 +238,7 @@ def test_library_created_mlb_session_retains_retry_policy_contract():
 
 
 def test_mlb_constructors_remain_compatible():
+    """Existing Mlb() positional constructor usage continues to work."""
     mlb_default = Mlb()
     try:
         assert isinstance(mlb_default._session, requests.Session)
@@ -266,6 +277,7 @@ def test_mlb_positional_timeout_remains_third_argument():
 
 
 def test_adapter_positional_construction_remains_compatible():
+    """Existing MlbDataAdapter positional construction order stays intact."""
     logger = MagicMock()
     session = RecordingSession()
     adapter = MlbDataAdapter("statsapi.mlb.com", "v1.1", logger, (5.0, 60.0), session)
@@ -283,6 +295,7 @@ def test_adapter_positional_construction_remains_compatible():
 
 
 def test_mlb_timeout_constructors_forward_to_both_adapters():
+    """Default, scalar, and tuple timeouts reach both v1 and v1.1 adapters."""
     default_session = RecordingSession()
     mlb_default = Mlb(session=default_session)
     mlb_default._mlb_adapter_v1.get(endpoint="sports")

--- a/tests/test_http_contract.py
+++ b/tests/test_http_contract.py
@@ -98,7 +98,7 @@ def test_status_matrices_document_compatibility_baseline():
 @pytest.mark.parametrize("status_code", COMPATIBILITY_CLIENT_ERRORS)
 def test_compatibility_client_errors_return_empty_mlb_result(status_code):
     reason = HTTP_REASON_BY_STATUS[status_code]
-    url = f"https://statsapi.mlb.com/api/v1/sports"
+    url = "https://statsapi.mlb.com/api/v1/sports"
     session = MagicMock()
     session.get.return_value = _response(
         status_code=status_code,

--- a/tests/test_mlb_retries.py
+++ b/tests/test_mlb_retries.py
@@ -14,20 +14,12 @@ from urllib3.util.retry import Retry
 
 from mlbstatsapi import Mlb, MlbDataAdapter, MlbHttpError, MlbResult
 
-
-def _assert_retry_policy(retry: Retry) -> None:
-    assert retry.total == 3
-    assert retry.connect == 3
-    assert retry.read == 2
-    assert retry.status == 3
-    assert retry.backoff_factor == 0.5
-    assert set(retry.status_forcelist) == {429, 500, 502, 503, 504}
-    assert retry.allowed_methods == frozenset({"GET"})
-    assert retry.respect_retry_after_header is True
-    assert retry.raise_on_status is False
-    assert "POST" not in retry.allowed_methods
-    assert "PATCH" not in retry.allowed_methods
-    assert "DELETE" not in retry.allowed_methods
+from http_contract_support import (
+    NON_RETRYABLE_CLIENT_ERRORS,
+    RETRYABLE_STATUS_CODES,
+    SERVER_ERRORS,
+    assert_library_retry_policy,
+)
 
 
 def test_library_created_mlb_session_has_retry_policy():
@@ -35,7 +27,7 @@ def test_library_created_mlb_session_has_retry_policy():
     try:
         for scheme in ("https://", "http://"):
             adapter = mlb._session.get_adapter(scheme)
-            _assert_retry_policy(adapter.max_retries)
+            assert_library_retry_policy(adapter.max_retries)
     finally:
         mlb.close()
 
@@ -45,7 +37,7 @@ def test_library_created_adapter_session_has_retry_policy():
     try:
         for scheme in ("https://", "http://"):
             http_adapter = adapter._session.get_adapter(scheme)
-            _assert_retry_policy(http_adapter.max_retries)
+            assert_library_retry_policy(http_adapter.max_retries)
     finally:
         adapter.close()
 
@@ -58,6 +50,7 @@ def test_injected_session_adapters_are_not_replaced():
     mlb = Mlb(session=session)
     try:
         assert session.get_adapter("https://") is custom_adapter
+        assert session.get_adapter("https://").max_retries.total == 0
     finally:
         mlb.close()
         session.close()
@@ -71,6 +64,7 @@ def test_injected_adapter_session_adapters_are_not_replaced():
     adapter = MlbDataAdapter(session=session)
     try:
         assert session.get_adapter("http://") is custom_adapter
+        assert session.get_adapter("http://").max_retries.total == 0
     finally:
         adapter.close()
         session.close()
@@ -159,10 +153,7 @@ def test_retries_recover_from_two_500_responses(
     assert _ScriptedHandler.request_count == 3
 
 
-@pytest.mark.parametrize(
-    "retryable_status",
-    [429, 500, 502, 503, 504],
-)
+@pytest.mark.parametrize("retryable_status", RETRYABLE_STATUS_CODES)
 def test_retries_retryable_statuses_then_succeed(
     retryable_status,
     scripted_http_server,
@@ -182,10 +173,7 @@ def test_retries_retryable_statuses_then_succeed(
     assert _ScriptedHandler.request_count == 2
 
 
-@pytest.mark.parametrize(
-    "status_code",
-    [400, 401, 403, 404],
-)
+@pytest.mark.parametrize("status_code", NON_RETRYABLE_CLIENT_ERRORS)
 def test_non_retryable_client_errors_are_not_retried(
     status_code,
     scripted_http_server,
@@ -205,12 +193,14 @@ def test_non_retryable_client_errors_are_not_retried(
     assert _ScriptedHandler.request_count == 1
 
 
-def test_bounded_persistent_500_raises_after_four_attempts(
+@pytest.mark.parametrize("status_code", SERVER_ERRORS)
+def test_bounded_persistent_server_errors_raise_after_four_attempts(
+    status_code,
     scripted_http_server,
     no_retry_sleep,
 ):
     configure, port = scripted_http_server
-    configure([500, 500, 500, 500, 500, 500])
+    configure([status_code] * 6)
     adapter = _adapter_against_local_server(port)
 
     try:
@@ -219,8 +209,7 @@ def test_bounded_persistent_500_raises_after_four_attempts(
     finally:
         adapter.close()
 
-    assert exc_info.value.status_code == 500
-    assert exc_info.value.reason == "Internal Server Error"
+    assert exc_info.value.status_code == status_code
     assert _ScriptedHandler.request_count == 4
 
 

--- a/tests/test_mlb_retries.py
+++ b/tests/test_mlb_retries.py
@@ -23,6 +23,7 @@ from http_contract_support import (
 
 
 def test_library_created_mlb_session_has_retry_policy():
+    """Library-created Mlb Sessions mount the default retry policy on http/https."""
     mlb = Mlb()
     try:
         for scheme in ("https://", "http://"):
@@ -33,6 +34,7 @@ def test_library_created_mlb_session_has_retry_policy():
 
 
 def test_library_created_adapter_session_has_retry_policy():
+    """Library-created MlbDataAdapter Sessions mount the default retry policy."""
     adapter = MlbDataAdapter()
     try:
         for scheme in ("https://", "http://"):
@@ -43,6 +45,7 @@ def test_library_created_adapter_session_has_retry_policy():
 
 
 def test_injected_session_adapters_are_not_replaced():
+    """Mlb must not replace adapters or retry config on an injected Session."""
     session = requests.Session()
     custom_adapter = HTTPAdapter(max_retries=0)
     session.mount("https://", custom_adapter)
@@ -57,6 +60,7 @@ def test_injected_session_adapters_are_not_replaced():
 
 
 def test_injected_adapter_session_adapters_are_not_replaced():
+    """Standalone adapters must not replace adapters on an injected Session."""
     session = requests.Session()
     custom_adapter = HTTPAdapter(max_retries=0)
     session.mount("http://", custom_adapter)
@@ -138,6 +142,7 @@ def test_retries_recover_from_two_500_responses(
     scripted_http_server,
     no_retry_sleep,
 ):
+    """Transient 500s are retried and a later 200 succeeds."""
     configure, port = scripted_http_server
     configure([500, 500, 200])
     adapter = _adapter_against_local_server(port)
@@ -159,6 +164,7 @@ def test_retries_retryable_statuses_then_succeed(
     scripted_http_server,
     no_retry_sleep,
 ):
+    """Each retryable status is retried once and can recover on success."""
     configure, port = scripted_http_server
     configure([retryable_status, 200])
     adapter = _adapter_against_local_server(port)
@@ -179,6 +185,7 @@ def test_non_retryable_client_errors_are_not_retried(
     scripted_http_server,
     no_retry_sleep,
 ):
+    """Ordinary client errors are returned immediately without retries."""
     configure, port = scripted_http_server
     configure([status_code, 200])
     adapter = _adapter_against_local_server(port)
@@ -199,6 +206,7 @@ def test_bounded_persistent_server_errors_raise_after_four_attempts(
     scripted_http_server,
     no_retry_sleep,
 ):
+    """Persistent server errors raise MlbHttpError after initial try plus 3 retries."""
     configure, port = scripted_http_server
     configure([status_code] * 6)
     adapter = _adapter_against_local_server(port)
@@ -217,6 +225,7 @@ def test_final_429_returns_empty_mlb_result(
     scripted_http_server,
     no_retry_sleep,
 ):
+    """After retry exhaustion, a final 429 still returns an empty MlbResult."""
     configure, port = scripted_http_server
     configure([429, 429, 429, 429, 429, 429])
     adapter = _adapter_against_local_server(port)
@@ -233,6 +242,7 @@ def test_final_429_returns_empty_mlb_result(
 
 
 def test_invalid_json_is_not_retried(no_retry_sleep):
+    """JSON decode failures are not treated as retryable transport errors."""
     class BadJsonHandler(_ScriptedHandler):
         def do_GET(self) -> None:  # noqa: N802
             with self.lock:

--- a/tests/test_mlb_session.py
+++ b/tests/test_mlb_session.py
@@ -200,6 +200,17 @@ def test_mlb_configured_timeout_reaches_both_adapters():
     assert session.calls[1]["url"].endswith("/api/v1.1/game")
 
 
+def test_mlb_scalar_timeout_reaches_both_adapters():
+    session = RecordingSession()
+    mlb = Mlb(session=session, timeout=10)
+
+    mlb._mlb_adapter_v1.get(endpoint="sports")
+    mlb._mlb_adapter_v1_1.get(endpoint="game")
+
+    assert session.calls[0]["timeout"] == 10
+    assert session.calls[1]["timeout"] == 10
+
+
 def test_mlb_default_timeout_passed_to_session():
     session = RecordingSession()
     mlb = Mlb(session=session)
@@ -216,9 +227,41 @@ def test_injected_session_is_shared_by_both_adapters():
     session = RecordingSession()
     mlb = Mlb(session=session)
 
+    assert mlb._session is session
     assert mlb._mlb_adapter_v1._session is session
     assert mlb._mlb_adapter_v1_1._session is session
     assert mlb._mlb_adapter_v1._session is mlb._mlb_adapter_v1_1._session
+
+
+def test_injected_session_is_not_replaced_with_library_session():
+    session = requests.Session()
+    with patch("mlbstatsapi.mlb_api.requests.Session") as session_cls:
+        mlb = Mlb(session=session)
+
+        session_cls.assert_not_called()
+        assert mlb._session is session
+        assert mlb._mlb_adapter_v1._session is session
+        assert mlb._mlb_adapter_v1_1._session is session
+        assert mlb._owns_session is False
+
+    mlb.close()
+    session.close()
+
+
+def test_injected_session_headers_and_user_agent_are_not_modified():
+    session = requests.Session()
+    session.headers["User-Agent"] = "caller-agent/1.0"
+    session.headers["X-Caller-Header"] = "keep-me"
+    headers_before = dict(session.headers)
+
+    mlb = Mlb(session=session)
+    try:
+        assert dict(session.headers) == headers_before
+        assert session.headers["User-Agent"] == "caller-agent/1.0"
+        assert session.headers["X-Caller-Header"] == "keep-me"
+    finally:
+        mlb.close()
+        session.close()
 
 
 def test_library_created_session_is_shared_by_both_adapters():

--- a/tests/test_mlb_session.py
+++ b/tests/test_mlb_session.py
@@ -201,6 +201,7 @@ def test_mlb_configured_timeout_reaches_both_adapters():
 
 
 def test_mlb_scalar_timeout_reaches_both_adapters():
+    """Scalar Mlb(timeout=...) values are forwarded unchanged to both adapters."""
     session = RecordingSession()
     mlb = Mlb(session=session, timeout=10)
 
@@ -234,6 +235,7 @@ def test_injected_session_is_shared_by_both_adapters():
 
 
 def test_injected_session_is_not_replaced_with_library_session():
+    """Caller-injected Sessions are used as-is; the library creates no replacement."""
     session = requests.Session()
     with patch("mlbstatsapi.mlb_api.requests.Session") as session_cls:
         mlb = Mlb(session=session)
@@ -249,6 +251,7 @@ def test_injected_session_is_not_replaced_with_library_session():
 
 
 def test_injected_session_headers_and_user_agent_are_not_modified():
+    """Injected Session headers, including User-Agent, stay under caller control."""
     session = requests.Session()
     session.headers["User-Agent"] = "caller-agent/1.0"
     session.headers["X-Caller-Header"] = "keep-me"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #266

## Summary

* protects existing HTTP compatibility behavior
* adds missing offline contract coverage
* prepares reusable status matrices or fixtures for later 0.9.0 work
* does not intentionally change production behavior

### Why

Version 0.9.0 will add configurable HTTP behavior on top of the transport work completed in version 0.8.0. This PR establishes a deterministic offline contract that protects the existing version 0.8.0 HTTP behavior before those features are implemented.

### What

* Adds `tests/http_contract_support.py` with reusable status matrices (`COMPATIBILITY_CLIENT_ERRORS`, `NOT_FOUND_STATUS`, `SERVER_ERRORS`, retryable/non-retryable groups) and a shared retry-policy assertion helper
* Adds `tests/test_http_contract.py` covering default non-404 4xx empty `MlbResult` behavior, public `Mlb` endpoint 404 return shapes (`None` / `[]` / `{}`), final 5xx `MlbHttpError` attributes, constructor/positional-argument compatibility, and timeout forwarding
* Extends session ownership coverage for injected Session headers/User-Agent and no Session replacement
* Expands retry tests to use the shared matrices, including 405/422 non-retry and 502/503/504 exhaustion

Intentionally left out of this PR:

* `create_retry_policy()` / public retry helpers
* `strict_http`
* `MlbHttpCompatibilityWarning`
* richer `MlbHttpError` context (`response_data`, `body_excerpt`)
* versioned User-Agent behavior

## Validation

* `poetry run pytest tests/ --ignore=tests/external_tests -v` (191 passed)
* `git diff --check`

## Base branch

`release/0.9.0`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7f76c54-e1b7-412a-86df-3692b764a49f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7f76c54-e1b7-412a-86df-3692b764a49f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

