### PR TITLE
Relax the MlbHttpError compatibility contract

### DIFF
--- a/tests/test_http_contract.py
+++ b/tests/test_http_contract.py
@@ -208,7 +208,7 @@ def test_mlb_server_errors_raise_mlb_http_error_with_existing_attributes(status_
     )
     mlb = Mlb(session=session)
 
-    with pytest.raises(MlbHttpError, match=rf"^{status_code}: {reason}$") as exc_info:
+    with pytest.raises(MlbHttpError) as exc_info:
         mlb.get_person(664034)
 
     exc = exc_info.value
@@ -216,6 +216,10 @@ def test_mlb_server_errors_raise_mlb_http_error_with_existing_attributes(status_
     assert exc.status_code == status_code
     assert exc.reason == reason
     assert exc.url == url
+    # Protect useful message content without freezing the full exception string;
+    # issue #268 may enrich MlbHttpError while keeping these attributes.
+    assert str(status_code) in str(exc)
+    assert reason in str(exc)
 
 
 # --- Library-created retry policy (contract-level guard) ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Refs #265
Follow-up to #273

## Summary

* continues protecting the existing `status_code`, `reason`, and `url` attributes
* avoids freezing the complete exception string so issue #268 can enrich `MlbHttpError`
* does not change production behavior

Note: PR #273 already dropped the `not hasattr(..., "response_data"|"body_excerpt")` guards before merge. This follow-up relaxes the remaining exact exception-message match.

### Why

The contract still frozen the full `MlbHttpError` message format (`^{status_code}: {reason}$`), which would block compatible message enrichment planned for #268. Structured attributes are the public compatibility surface; the exact string format is not.

### What

* Relaxed `test_mlb_server_errors_raise_mlb_http_error_with_existing_attributes` to assert `MlbHttpError` without an exact message match
* Kept structured attribute checks for `status_code`, `reason`, and `url`
* Retained looser message checks that status code and reason still appear in `str(exc)`

### Tests

* `poetry run pytest tests/test_http_contract.py -v` — 26 passed
* `poetry run pytest tests/ --ignore=tests/external_tests -v` — 191 passed
* `git diff --check` — clean
* Diff limited to `tests/test_http_contract.py`

### Risk and impact

- Minimal — test-only change; no production HTTP behavior changes

## Validation

* `poetry run pytest tests/test_http_contract.py -v`
* `poetry run pytest tests/ --ignore=tests/external_tests -v`
* `git diff --check`

## Base branch

`release/0.9.0`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-acd0e6e0-6d02-4459-b709-60d0765a62a5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-acd0e6e0-6d02-4459-b709-60d0765a62a5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

