### PR TITLE
Expose the default retry policy

### DIFF
--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -138,7 +138,10 @@ Callers who inject a Session control its retry, TLS, proxy, and adapter configur
 
 ## Default retry policy
 
-Library-created Sessions mount a bounded retry policy for GET requests.
+Library-created Sessions mount a bounded retry policy for GET requests automatically.
+
+Caller-injected Sessions are never automatically reconfigured. Retry settings on an
+injected Session remain under the caller's control unless the caller opts in.
 
 ```text
 Initial request: 1
@@ -180,6 +183,40 @@ Additional rules:
 * A final 5xx raises `MlbHttpError`
 
 Retries improve resilience for transient failures. They do not guarantee success.
+
+## Reusing the retry policy on a caller-managed Session
+
+`create_retry_policy()` returns a new instance of the same tested retry policy used
+internally for library-created Sessions.
+
+Callers who inject a Session must mount the policy themselves. The library does not
+install or replace adapters on caller-injected Sessions.
+
+Callers retain control over connection-pool sizes and other `HTTPAdapter` options.
+The caller remains responsible for closing an injected Session.
+
+```python
+import requests
+import mlbstatsapi
+
+session = requests.Session()
+adapter = requests.adapters.HTTPAdapter(
+    max_retries=mlbstatsapi.create_retry_policy(),
+    pool_connections=10,
+    pool_maxsize=20,
+)
+session.mount("https://", adapter)
+session.mount("http://", adapter)
+
+try:
+    with mlbstatsapi.Mlb(session=session) as mlb:
+        player = mlb.get_person(664034)
+finally:
+    session.close()
+```
+
+Mounting the same adapter instance for both schemes is valid. Callers may also mount
+separate adapters when they need different settings for HTTP and HTTPS.
 
 ## Structured exceptions
 

--- a/mlbstatsapi/__init__.py
+++ b/mlbstatsapi/__init__.py
@@ -1,5 +1,5 @@
 from .mlb_api import Mlb
-from .mlb_dataadapter import MlbDataAdapter, MlbResult
+from .mlb_dataadapter import MlbDataAdapter, MlbResult, create_retry_policy
 from .exceptions import (
     MlbDecodeError,
     MlbHttpError,

--- a/mlbstatsapi/mlb_dataadapter.py
+++ b/mlbstatsapi/mlb_dataadapter.py
@@ -18,7 +18,8 @@ DEFAULT_TIMEOUT = (3.05, 30.0)
 TimeoutType = int | float | tuple[float, float]
 
 
-def _build_retry_policy() -> Retry:
+def create_retry_policy() -> Retry:
+    """Create a new instance of the default MLB HTTP retry policy."""
     return Retry(
         total=3,
         connect=3,
@@ -49,13 +50,13 @@ def _configure_retry_adapters(
     session.mount(
         "https://",
         HTTPAdapter(
-            max_retries=_build_retry_policy()
+            max_retries=create_retry_policy(),
         ),
     )
     session.mount(
         "http://",
         HTTPAdapter(
-            max_retries=_build_retry_policy()
+            max_retries=create_retry_policy(),
         ),
     )
 

--- a/tests/http_contract_support.py
+++ b/tests/http_contract_support.py
@@ -68,10 +68,10 @@ HTTP_REASON_BY_STATUS = {
 
 
 def assert_library_retry_policy(retry: Retry) -> None:
-    """Assert the library-created Session retry policy values.
+    """Assert the default library retry policy values.
 
-    Kept in tests so retry and contract modules share one source of truth
-    without exposing a public production helper.
+    Kept in tests so retry and contract modules share one assertion helper
+    for the public `create_retry_policy()` configuration.
     """
     assert retry.total == 3
     assert retry.connect == 3

--- a/tests/test_mlb_retries.py
+++ b/tests/test_mlb_retries.py
@@ -12,8 +12,8 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from mlbstatsapi import Mlb, MlbDataAdapter, MlbHttpError, MlbResult, create_retry_policy
 import mlbstatsapi
+from mlbstatsapi import Mlb, MlbDataAdapter, MlbHttpError, MlbResult, create_retry_policy
 
 from http_contract_support import (
     NON_RETRYABLE_CLIENT_ERRORS,
@@ -112,6 +112,7 @@ def test_caller_can_opt_in_to_public_retry_policy():
     mlb = Mlb(session=session)
     try:
         assert mlb._session is session
+        assert mlb._owns_session is False
         assert session.get_adapter("https://") is https_adapter
         assert session.get_adapter("http://") is http_adapter
         assert_library_retry_policy(https_adapter.max_retries)
@@ -119,7 +120,9 @@ def test_caller_can_opt_in_to_public_retry_policy():
         assert https_adapter.max_retries is not http_adapter.max_retries
     finally:
         mlb.close()
-        assert not getattr(session, "closed", False)
+        # Injected Sessions remain caller-owned after Mlb.close().
+        assert session.get_adapter("https://") is https_adapter
+        assert session.get_adapter("http://") is http_adapter
         session.close()
 
 

--- a/tests/test_mlb_retries.py
+++ b/tests/test_mlb_retries.py
@@ -12,7 +12,8 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from mlbstatsapi import Mlb, MlbDataAdapter, MlbHttpError, MlbResult
+from mlbstatsapi import Mlb, MlbDataAdapter, MlbHttpError, MlbResult, create_retry_policy
+import mlbstatsapi
 
 from http_contract_support import (
     NON_RETRYABLE_CLIENT_ERRORS,
@@ -22,13 +23,37 @@ from http_contract_support import (
 )
 
 
+def test_create_retry_policy_is_publicly_importable():
+    """create_retry_policy is available through the package public API."""
+    assert callable(mlbstatsapi.create_retry_policy)
+    assert create_retry_policy is mlbstatsapi.create_retry_policy
+
+
+def test_create_retry_policy_returns_retry_instance():
+    """create_retry_policy returns an urllib3 Retry with the library policy."""
+    policy = create_retry_policy()
+    assert isinstance(policy, Retry)
+    assert_library_retry_policy(policy)
+
+
+def test_create_retry_policy_returns_independent_instances():
+    """Each call returns a distinct Retry instance with the same configuration."""
+    first = create_retry_policy()
+    second = create_retry_policy()
+    assert first is not second
+    assert_library_retry_policy(first)
+    assert_library_retry_policy(second)
+
+
 def test_library_created_mlb_session_has_retry_policy():
     """Library-created Mlb Sessions mount the default retry policy on http/https."""
     mlb = Mlb()
     try:
-        for scheme in ("https://", "http://"):
-            adapter = mlb._session.get_adapter(scheme)
-            assert_library_retry_policy(adapter.max_retries)
+        https_adapter = mlb._session.get_adapter("https://")
+        http_adapter = mlb._session.get_adapter("http://")
+        assert_library_retry_policy(https_adapter.max_retries)
+        assert_library_retry_policy(http_adapter.max_retries)
+        assert https_adapter.max_retries is not http_adapter.max_retries
     finally:
         mlb.close()
 
@@ -37,9 +62,11 @@ def test_library_created_adapter_session_has_retry_policy():
     """Library-created MlbDataAdapter Sessions mount the default retry policy."""
     adapter = MlbDataAdapter()
     try:
-        for scheme in ("https://", "http://"):
-            http_adapter = adapter._session.get_adapter(scheme)
-            assert_library_retry_policy(http_adapter.max_retries)
+        https_adapter = adapter._session.get_adapter("https://")
+        http_adapter = adapter._session.get_adapter("http://")
+        assert_library_retry_policy(https_adapter.max_retries)
+        assert_library_retry_policy(http_adapter.max_retries)
+        assert https_adapter.max_retries is not http_adapter.max_retries
     finally:
         adapter.close()
 
@@ -71,6 +98,28 @@ def test_injected_adapter_session_adapters_are_not_replaced():
         assert session.get_adapter("http://").max_retries.total == 0
     finally:
         adapter.close()
+        session.close()
+
+
+def test_caller_can_opt_in_to_public_retry_policy():
+    """Callers may mount create_retry_policy() on their own Session."""
+    session = requests.Session()
+    https_adapter = HTTPAdapter(max_retries=create_retry_policy())
+    http_adapter = HTTPAdapter(max_retries=create_retry_policy())
+    session.mount("https://", https_adapter)
+    session.mount("http://", http_adapter)
+
+    mlb = Mlb(session=session)
+    try:
+        assert mlb._session is session
+        assert session.get_adapter("https://") is https_adapter
+        assert session.get_adapter("http://") is http_adapter
+        assert_library_retry_policy(https_adapter.max_retries)
+        assert_library_retry_policy(http_adapter.max_retries)
+        assert https_adapter.max_retries is not http_adapter.max_retries
+    finally:
+        mlb.close()
+        assert not getattr(session, "closed", False)
         session.close()
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #267
Refs #265

## Summary
* exposes the library's default retry policy through `create_retry_policy()`
* uses the public function for library-created Sessions
* allows caller-managed Sessions to explicitly opt into the tested policy
* preserves caller ownership of injected Sessions and adapters
* documents manual adapter configuration

## Validation
* `poetry run pytest tests/test_mlb_retries.py -v` — passed
* `poetry run pytest tests/test_mlb_session.py -v` — passed
* `poetry run pytest tests/test_http_contract.py -v` — passed
* `poetry run pytest tests/ --ignore=tests/external_tests -v` — 195 passed
* `git diff --check` — passed

## Base branch
`release/0.9.0`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9b1b047-fadb-4150-b0bb-ba40ed3ec2b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9b1b047-fadb-4150-b0bb-ba40ed3ec2b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

