### PR TITLE
Add richer context to MlbHttpError

### DIFF
--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -243,12 +243,64 @@ Notes:
 `MlbHttpError` exposes:
 
 ```text
+method
+status_code
+reason
+url
+response_data
+body_excerpt
+```
+
+Existing attributes remain compatible:
+
+```text
 status_code
 reason
 url
 ```
 
-It does not expose a response body or Response object.
+Additional context:
+
+* `method` is the HTTP method when the adapter raises the error (`GET` today). Manually constructed exceptions without a method leave `method` as `None`.
+* `response_data` contains a decoded JSON dictionary or list when the error body is valid JSON of that shape.
+* `response_data` is `None` for invalid JSON, HTML, plain text, empty bodies, or JSON scalars such as strings, numbers, booleans, or null.
+* `body_excerpt` contains at most 500 characters of the response text for non-empty bodies.
+* `body_excerpt` is `None` for an empty body.
+* Error-context extraction is best-effort. A parsing or decoding failure while collecting context must not replace the original HTTP error.
+* Complete `requests.Response` objects are not exposed.
+* Complete large response bodies are not preserved beyond the excerpt limit.
+* Response bodies are not automatically logged.
+* `str(exc)` remains concise, for example `500: Internal Server Error`, and does not include the response body, excerpt, or `response_data`.
+
+Usage:
+
+```python
+try:
+    player = mlb.get_person(664034)
+except mlbstatsapi.MlbHttpError as exc:
+    print(exc.method)
+    print(exc.status_code)
+    print(exc.reason)
+    print(exc.url)
+    print(exc.response_data)
+    print(exc.body_excerpt)
+```
+
+Precise handling with the expanded attributes:
+
+```python
+try:
+    player = mlb.get_person(664034)
+except MlbHttpError as exc:
+    print(
+        exc.method,
+        exc.status_code,
+        exc.reason,
+        exc.url,
+        exc.response_data,
+        exc.body_excerpt,
+    )
+```
 
 ## Existing 404 behavior
 

--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -286,22 +286,6 @@ except mlbstatsapi.MlbHttpError as exc:
     print(exc.body_excerpt)
 ```
 
-Precise handling with the expanded attributes:
-
-```python
-try:
-    player = mlb.get_person(664034)
-except MlbHttpError as exc:
-    print(
-        exc.method,
-        exc.status_code,
-        exc.reason,
-        exc.url,
-        exc.response_data,
-        exc.body_excerpt,
-    )
-```
-
 ## Existing 404 behavior
 
 Version 0.8.0 preserves endpoint-specific not-found behavior.

--- a/mlbstatsapi/exceptions.py
+++ b/mlbstatsapi/exceptions.py
@@ -18,10 +18,17 @@ class MlbHttpError(TheMlbStatsApiException):
         status_code: int,
         reason: str,
         url: str | None = None,
+        *,
+        method: str | None = None,
+        response_data: dict | list | None = None,
+        body_excerpt: str | None = None,
     ):
         self.status_code = int(status_code)
         self.reason = str(reason)
         self.url = url
+        self.method = method.upper() if method is not None else None
+        self.response_data = response_data
+        self.body_excerpt = body_excerpt
 
         super().__init__(
             f"{self.status_code}: {self.reason}"

--- a/mlbstatsapi/mlb_dataadapter.py
+++ b/mlbstatsapi/mlb_dataadapter.py
@@ -17,6 +17,80 @@ from urllib3.util.retry import Retry
 DEFAULT_TIMEOUT = (3.05, 30.0)
 TimeoutType = int | float | tuple[float, float]
 
+# Bounded excerpt for error response bodies attached to MlbHttpError.
+HTTP_ERROR_BODY_EXCERPT_LIMIT = 500
+
+
+def _extract_error_response_data(
+    response: requests.Response,
+) -> dict | list | None:
+    """Best-effort JSON object/list extraction from an error response.
+
+    Returns None for empty bodies, invalid JSON, scalars, or unexpected failures.
+    Must not raise; context extraction cannot replace the original HTTP error.
+    """
+    try:
+        if not response.content:
+            return None
+        data = response.json()
+    except Exception:
+        return None
+
+    if isinstance(data, (dict, list)):
+        return data
+    return None
+
+
+def _extract_error_body_excerpt(
+    response: requests.Response,
+) -> str | None:
+    """Best-effort bounded text excerpt from an error response body.
+
+    Returns None for empty bodies or unexpected text-decoding failures.
+    Must not raise; context extraction cannot replace the original HTTP error.
+    """
+    try:
+        if not response.content:
+            return None
+        text = response.text
+    except Exception:
+        return None
+
+    if not text:
+        return None
+    return text[:HTTP_ERROR_BODY_EXCERPT_LIMIT]
+
+
+def _build_http_error(
+    response: requests.Response,
+    *,
+    method: str,
+    fallback_url: str,
+) -> MlbHttpError:
+    """Build an MlbHttpError with best-effort response context.
+
+    Extraction failures must not prevent raising MlbHttpError with status,
+    reason, URL, and method.
+    """
+    try:
+        response_data = _extract_error_response_data(response)
+    except Exception:
+        response_data = None
+
+    try:
+        body_excerpt = _extract_error_body_excerpt(response)
+    except Exception:
+        body_excerpt = None
+
+    return MlbHttpError(
+        status_code=response.status_code,
+        reason=response.reason,
+        url=response.url or fallback_url,
+        method=method,
+        response_data=response_data,
+        body_excerpt=body_excerpt,
+    )
+
 
 def _build_retry_policy() -> Retry:
     return Retry(
@@ -180,17 +254,17 @@ class MlbDataAdapter:
                 response.reason,
                 response.url,
             ))
-            raise MlbHttpError(
-                status_code=status_code,
-                reason=response.reason,
-                url=response.url,
+            raise _build_http_error(
+                response,
+                method="GET",
+                fallback_url=full_url,
             )
 
         if not 200 <= status_code <= 299:
-            raise MlbHttpError(
-                status_code=status_code,
-                reason=response.reason,
-                url=response.url,
+            raise _build_http_error(
+                response,
+                method="GET",
+                fallback_url=full_url,
             )
 
         self._logger.debug(msg=logline_post.format(

--- a/tests/test_mlb_exceptions.py
+++ b/tests/test_mlb_exceptions.py
@@ -1,5 +1,7 @@
 """Offline tests for the structured MLB Stats API exception hierarchy."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 import requests
 
@@ -11,6 +13,10 @@ from mlbstatsapi import (
     MlbTimeoutError,
     MlbTransportError,
     TheMlbStatsApiException,
+)
+from mlbstatsapi.mlb_dataadapter import (
+    HTTP_ERROR_BODY_EXCERPT_LIMIT,
+    _build_http_error,
 )
 
 
@@ -54,6 +60,33 @@ def test_mlb_http_error_attributes_and_message():
     assert exc.reason == "Internal Server Error"
     assert exc.url == "https://statsapi.mlb.com/api/v1/sports"
     assert str(exc) == "500: Internal Server Error"
+
+
+def test_mlb_http_error_positional_construction_preserves_compat():
+    exc = MlbHttpError(
+        500,
+        "Internal Server Error",
+        "https://example.test",
+    )
+
+    assert exc.status_code == 500
+    assert exc.reason == "Internal Server Error"
+    assert exc.url == "https://example.test"
+    assert exc.method is None
+    assert exc.response_data is None
+    assert exc.body_excerpt is None
+    assert isinstance(exc, TheMlbStatsApiException)
+    assert str(exc) == "500: Internal Server Error"
+
+
+def test_mlb_http_error_method_normalized_to_uppercase():
+    exc = MlbHttpError(
+        500,
+        "Internal Server Error",
+        method="get",
+    )
+
+    assert exc.method == "GET"
 
 
 def test_timeout_raises_mlb_timeout_error():
@@ -112,7 +145,7 @@ def test_connection_error_raises_mlb_transport_error():
 def test_invalid_json_raises_mlb_decode_error(requests_mock):
     requests_mock.get(
         f"{BASE_URL}sports",
-        text='{"some bad json": sdfsd',
+        text=\'{"some bad json": sdfsd\',
         status_code=200,
         reason="OK",
         headers={"Content-Type": "application/json"},
@@ -153,7 +186,285 @@ def test_server_error_raises_mlb_http_error(status_code, reason, requests_mock):
     assert exc_info.value.status_code == status_code
     assert exc_info.value.reason == reason
     assert exc_info.value.url == url
+    assert exc_info.value.method == "GET"
     assert str(exc_info.value) == f"{status_code}: {reason}"
+    adapter.close()
+
+
+def test_json_object_error_populates_response_data(requests_mock):
+    payload = {
+        "message": "Internal error occurred",
+        "code": "SERVICE_FAILURE",
+    }
+    url = f"{BASE_URL}sports"
+    requests_mock.get(
+        url,
+        json=payload,
+        status_code=500,
+        reason="Internal Server Error",
+    )
+    adapter = MlbDataAdapter()
+
+    with pytest.raises(MlbHttpError) as exc_info:
+        adapter.get(endpoint="sports")
+
+    exc = exc_info.value
+    assert exc.method == "GET"
+    assert exc.response_data == payload
+    assert exc.body_excerpt is not None
+    assert len(exc.body_excerpt) <= HTTP_ERROR_BODY_EXCERPT_LIMIT
+    assert "Internal error occurred" in exc.body_excerpt
+    assert str(exc) == "500: Internal Server Error"
+    adapter.close()
+
+
+def test_json_list_error_populates_response_data(requests_mock):
+    payload = [{"message": "error"}, {"message": "another"}]
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        json=payload,
+        status_code=500,
+        reason="Internal Server Error",
+    )
+    adapter = MlbDataAdapter()
+
+    with pytest.raises(MlbHttpError) as exc_info:
+        adapter.get(endpoint="sports")
+
+    assert exc_info.value.response_data == payload
+    assert exc_info.value.method == "GET"
+    adapter.close()
+
+
+def test_invalid_json_error_keeps_mlb_http_error(requests_mock):
+    malformed = \'{"message": broken\'
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        text=malformed,
+        status_code=500,
+        reason="Internal Server Error",
+        headers={"Content-Type": "application/json"},
+    )
+    adapter = MlbDataAdapter()
+
+    with pytest.raises(MlbHttpError) as exc_info:
+        adapter.get(endpoint="sports")
+
+    exc = exc_info.value
+    assert not isinstance(exc, MlbDecodeError)
+    assert exc.response_data is None
+    assert exc.body_excerpt == malformed
+    assert str(exc) == "500: Internal Server Error"
+    adapter.close()
+
+
+def test_html_error_response_context(requests_mock):
+    html = "<html><body>Internal Server Error</body></html>"
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        text=html,
+        status_code=500,
+        reason="Internal Server Error",
+        headers={"Content-Type": "text/html"},
+    )
+    adapter = MlbDataAdapter()
+
+    with pytest.raises(MlbHttpError) as exc_info:
+        adapter.get(endpoint="sports")
+
+    exc = exc_info.value
+    assert exc.response_data is None
+    assert html in (exc.body_excerpt or "")
+    adapter.close()
+
+
+def test_plain_text_error_response_context(requests_mock):
+    text = "temporary failure, try again later"
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        text=text,
+        status_code=503,
+        reason="Service Unavailable",
+        headers={"Content-Type": "text/plain"},
+    )
+    adapter = MlbDataAdapter()
+
+    with pytest.raises(MlbHttpError) as exc_info:
+        adapter.get(endpoint="sports")
+
+    exc = exc_info.value
+    assert exc.response_data is None
+    assert text in (exc.body_excerpt or "")
+    adapter.close()
+
+
+def test_empty_error_response_context(requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        text="",
+        status_code=500,
+        reason="Internal Server Error",
+    )
+    adapter = MlbDataAdapter()
+
+    with pytest.raises(MlbHttpError) as exc_info:
+        adapter.get(endpoint="sports")
+
+    exc = exc_info.value
+    assert exc.response_data is None
+    assert exc.body_excerpt is None
+    adapter.close()
+
+
+def test_large_error_body_excerpt_is_bounded(requests_mock):
+    body = "x" * (HTTP_ERROR_BODY_EXCERPT_LIMIT + 250)
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        text=body,
+        status_code=500,
+        reason="Internal Server Error",
+        headers={"Content-Type": "text/plain"},
+    )
+    adapter = MlbDataAdapter()
+
+    with pytest.raises(MlbHttpError) as exc_info:
+        adapter.get(endpoint="sports")
+
+    exc = exc_info.value
+    assert len(exc.body_excerpt) <= HTTP_ERROR_BODY_EXCERPT_LIMIT
+    assert exc.body_excerpt == body[:HTTP_ERROR_BODY_EXCERPT_LIMIT]
+    assert body not in str(exc)
+    assert str(exc) == "500: Internal Server Error"
+    adapter.close()
+
+
+def test_json_scalar_error_response_data_is_none(requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        text=\'"server unavailable"\',
+        status_code=500,
+        reason="Internal Server Error",
+        headers={"Content-Type": "application/json"},
+    )
+    adapter = MlbDataAdapter()
+
+    with pytest.raises(MlbHttpError) as exc_info:
+        adapter.get(endpoint="sports")
+
+    exc = exc_info.value
+    assert exc.response_data is None
+    assert "server unavailable" in (exc.body_excerpt or "")
+    adapter.close()
+
+
+def test_non_ascii_error_body_excerpt(requests_mock):
+    text = "エラー: サーバー障害 — café"
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        text=text,
+        status_code=500,
+        reason="Internal Server Error",
+        headers={"Content-Type": "text/plain; charset=utf-8"},
+    )
+    adapter = MlbDataAdapter()
+
+    with pytest.raises(MlbHttpError) as exc_info:
+        adapter.get(endpoint="sports")
+
+    assert text in (exc_info.value.body_excerpt or "")
+    adapter.close()
+
+
+def test_unexpected_status_raises_mlb_http_error_with_context(requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        text="redirect loop",
+        status_code=308,
+        reason="Permanent Redirect",
+    )
+    adapter = MlbDataAdapter()
+
+    with pytest.raises(MlbHttpError) as exc_info:
+        adapter.get(endpoint="sports")
+
+    exc = exc_info.value
+    assert exc.status_code == 308
+    assert exc.method == "GET"
+    assert exc.response_data is None
+    assert "redirect loop" in (exc.body_excerpt or "")
+    adapter.close()
+
+
+def test_url_fallback_when_response_url_missing():
+    response = MagicMock()
+    response.status_code = 500
+    response.reason = "Internal Server Error"
+    response.url = ""
+    response.content = b\'{"message": "boom"}\'
+    response.json.return_value = {"message": "boom"}
+    response.text = \'{"message": "boom"}\'
+
+    exc = _build_http_error(
+        response,
+        method="GET",
+        fallback_url=f"{BASE_URL}sports",
+    )
+
+    assert exc.url == f"{BASE_URL}sports"
+    assert exc.method == "GET"
+    assert exc.response_data == {"message": "boom"}
+
+
+def test_best_effort_extraction_failure_still_raises_mlb_http_error(requests_mock):
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        text="failure body",
+        status_code=500,
+        reason="Internal Server Error",
+    )
+    adapter = MlbDataAdapter()
+
+    with (
+        patch(
+            "mlbstatsapi.mlb_dataadapter._extract_error_response_data",
+            side_effect=RuntimeError("unexpected json failure"),
+        ),
+        patch(
+            "mlbstatsapi.mlb_dataadapter._extract_error_body_excerpt",
+            side_effect=RuntimeError("unexpected text failure"),
+        ),
+        pytest.raises(MlbHttpError) as exc_info,
+    ):
+        adapter.get(endpoint="sports")
+
+    exc = exc_info.value
+    assert exc.status_code == 500
+    assert exc.reason == "Internal Server Error"
+    assert exc.url == f"{BASE_URL}sports"
+    assert exc.method == "GET"
+    assert exc.response_data is None
+    assert exc.body_excerpt is None
+    assert str(exc) == "500: Internal Server Error"
+    adapter.close()
+
+
+def test_error_response_body_is_not_logged(requests_mock, caplog):
+    secret = "DO-NOT-LOG-THIS-BODY"
+    requests_mock.get(
+        f"{BASE_URL}sports",
+        text=secret,
+        status_code=500,
+        reason="Internal Server Error",
+        headers={"Content-Type": "text/plain"},
+    )
+    adapter = MlbDataAdapter()
+
+    with pytest.raises(MlbHttpError) as exc_info:
+        adapter.get(endpoint="sports")
+
+    assert secret in (exc_info.value.body_excerpt or "")
+    logged = " ".join(record.getMessage() for record in caplog.records)
+    assert secret not in logged
     adapter.close()
 
 

--- a/tests/test_mlb_exceptions.py
+++ b/tests/test_mlb_exceptions.py
@@ -145,7 +145,7 @@ def test_connection_error_raises_mlb_transport_error():
 def test_invalid_json_raises_mlb_decode_error(requests_mock):
     requests_mock.get(
         f"{BASE_URL}sports",
-        text=\'{"some bad json": sdfsd\',
+        text='{"some bad json": sdfsd',
         status_code=200,
         reason="OK",
         headers={"Content-Type": "application/json"},
@@ -237,7 +237,7 @@ def test_json_list_error_populates_response_data(requests_mock):
 
 
 def test_invalid_json_error_keeps_mlb_http_error(requests_mock):
-    malformed = \'{"message": broken\'
+    malformed = '{"message": broken'
     requests_mock.get(
         f"{BASE_URL}sports",
         text=malformed,
@@ -341,7 +341,7 @@ def test_large_error_body_excerpt_is_bounded(requests_mock):
 def test_json_scalar_error_response_data_is_none(requests_mock):
     requests_mock.get(
         f"{BASE_URL}sports",
-        text=\'"server unavailable"\',
+        text='"server unavailable"',
         status_code=500,
         reason="Internal Server Error",
         headers={"Content-Type": "application/json"},
@@ -400,9 +400,9 @@ def test_url_fallback_when_response_url_missing():
     response.status_code = 500
     response.reason = "Internal Server Error"
     response.url = ""
-    response.content = b\'{"message": "boom"}\'
+    response.content = b'{"message": "boom"}'
     response.json.return_value = {"message": "boom"}
-    response.text = \'{"message": "boom"}\'
+    response.text = '{"message": "boom"}'
 
     exc = _build_http_error(
         response,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #268
Refs #265

## Summary
* adds request method and bounded response context to `MlbHttpError`
* preserves existing exception attributes and inheritance
* captures valid JSON dictionaries and lists when available
* preserves a bounded text excerpt for non-empty error responses
* prevents context extraction from hiding the original HTTP error
* does not change which HTTP statuses raise

## Validation
* `poetry run pytest tests/test_mlb_exceptions.py -v` — 29 passed
* `poetry run pytest tests/test_http_contract.py -v` — 26 passed
* `poetry run pytest tests/test_mlb_retries.py -v` — 22 passed
* `poetry run pytest tests/test_mlb_session.py -v` — 34 passed
* `poetry run pytest tests/ --ignore=tests/external_tests -v` — 206 passed
* `git diff --check` — clean

## Base branch
`release/0.9.0`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7d5ec2e-1063-442d-b640-99a42cd56933?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7d5ec2e-1063-442d-b640-99a42cd56933&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

