### PR TITLE
Add warnings for future strict HTTP behavior

### DIFF
--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -227,6 +227,7 @@ Notes:
 * Strict mode does not change transport or decode exceptions
 * Strict-mode exceptions include the richer context from `MlbHttpError`
 * Existing constructor usage remains valid
+* Compatibility mode emits `MlbHttpCompatibilityWarning` for a suppressed non-404 4xx
 
 Example:
 
@@ -244,6 +245,94 @@ except mlbstatsapi.MlbHttpError as exc:
     print(exc.response_data)
     print(exc.body_excerpt)
 ```
+
+## Compatibility warnings
+
+Version 0.9.0 emits `MlbHttpCompatibilityWarning` when compatibility mode returns the
+historical empty result for a final non-404 4xx response.
+
+The warning means strict mode would have raised `MlbHttpError` for the same response.
+
+```python
+import mlbstatsapi
+
+mlb = mlbstatsapi.Mlb()
+sports = mlb.get_sports()
+```
+
+A representative warning looks like:
+
+```text
+HTTP 403 for https://statsapi.mlb.com/api/v1/sports was handled through
+compatibility mode and returned the historical empty result. Pass
+strict_http=True to raise MlbHttpError. This compatibility behavior may
+change in version 1.0.
+```
+
+The category inherits from `FutureWarning` so the migration notice stays visible under
+default Python warning filters.
+
+When the warning is emitted:
+
+| Response                  | Warning |
+| ------------------------- | ------- |
+| Non-404 4xx, compatibility mode | Yes |
+| Final 429, compatibility mode, after retries | Yes |
+| Non-404 4xx, strict mode  | No, `MlbHttpError` is raised instead |
+| 404, either mode          | No      |
+| Successful 2xx            | No      |
+| Final 5xx                 | No, `MlbHttpError` is raised in both modes |
+| Timeout, transport, decode, or validation failure | No |
+
+Additional rules:
+
+* The warning never changes the return value; compatibility mode still returns the
+  historical empty result in version 0.9.0
+* A final 404 remains warning-free and keeps existing `None` / `[]` / `{}` behavior
+* Warnings are emitted only after retries are exhausted, so a retried 429 warns once
+* Strict mode does not warn because it raises `MlbHttpError` directly
+* Warning messages contain only the status code and request URL, never response
+  bodies, headers, or credentials
+* Stricter defaults may be introduced in version 1.0
+
+Enabling strict mode is the recommended migration:
+
+```python
+import mlbstatsapi
+
+mlb = mlbstatsapi.Mlb(
+    strict_http=True,
+)
+```
+
+Applications may also turn only this package warning into an exception:
+
+```python
+import warnings
+import mlbstatsapi
+
+warnings.filterwarnings(
+    "error",
+    category=mlbstatsapi.MlbHttpCompatibilityWarning,
+)
+```
+
+Or silence only this category:
+
+```python
+import warnings
+import mlbstatsapi
+
+warnings.filterwarnings(
+    "ignore",
+    category=mlbstatsapi.MlbHttpCompatibilityWarning,
+)
+```
+
+Prefer enabling strict mode over permanently ignoring the warning when the application
+wants explicit HTTP failures. Filter by `mlbstatsapi.MlbHttpCompatibilityWarning` rather
+than disabling all `FutureWarning` or all warnings, which would also hide unrelated
+notices from other libraries.
 
 ## Reusing the retry policy on a caller-managed Session
 

--- a/mlbstatsapi/__init__.py
+++ b/mlbstatsapi/__init__.py
@@ -7,6 +7,7 @@ from .exceptions import (
     MlbTransportError,
     TheMlbStatsApiException,
 )
+from .warnings import MlbHttpCompatibilityWarning
 
 from .mlb_module import (
     return_splits,

--- a/mlbstatsapi/mlb_dataadapter.py
+++ b/mlbstatsapi/mlb_dataadapter.py
@@ -6,7 +6,9 @@ from .exceptions import (
     MlbTimeoutError,
     MlbTransportError,
 )
+from .warnings import MlbHttpCompatibilityWarning
 import logging
+import warnings
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -19,6 +21,32 @@ TimeoutType = int | float | tuple[float, float]
 
 # Bounded excerpt for error response bodies attached to MlbHttpError.
 HTTP_ERROR_BODY_EXCERPT_LIMIT = 500
+
+# Frames from warnings.warn() out to whoever called MlbDataAdapter.get(), so the
+# warning points at application code rather than the helper below.
+COMPATIBILITY_WARNING_STACKLEVEL = 3
+
+
+def _warn_http_compatibility(
+    *,
+    status_code: int,
+    url: str,
+) -> None:
+    """Warn that compatibility mode suppressed an error strict mode would raise.
+
+    Only the status code and URL are reported; response bodies, headers, and
+    credentials must never reach a warning message.
+    """
+    warnings.warn(
+        (
+            f"HTTP {status_code} for {url} was handled through compatibility mode "
+            "and returned the historical empty result. Pass strict_http=True to "
+            "raise MlbHttpError. This compatibility behavior may change in "
+            "version 1.0."
+        ),
+        MlbHttpCompatibilityWarning,
+        stacklevel=COMPATIBILITY_WARNING_STACKLEVEL,
+    )
 
 
 def _extract_error_response_data(
@@ -252,6 +280,11 @@ class MlbDataAdapter:
                     response,
                     method="GET",
                     fallback_url=full_url,
+                )
+            if status_code != 404:
+                _warn_http_compatibility(
+                    status_code=status_code,
+                    url=response.url or full_url,
                 )
             return MlbResult(
                 status_code=status_code,

--- a/mlbstatsapi/warnings.py
+++ b/mlbstatsapi/warnings.py
@@ -1,0 +1,13 @@
+"""Package warning categories.
+
+Kept in a dedicated module so callers can filter package warnings by class
+without importing the HTTP adapter internals.
+"""
+
+
+class MlbHttpCompatibilityWarning(FutureWarning):
+    """A compatibility-mode HTTP response that strict mode would raise.
+
+    FutureWarning is used instead of DeprecationWarning because this notice is
+    aimed at application users and must stay visible under default filters.
+    """

--- a/tests/test_http_warnings.py
+++ b/tests/test_http_warnings.py
@@ -1,0 +1,437 @@
+"""Offline tests for the compatibility-mode HTTP warning added in version 0.9.0.
+
+Kept separate from the strict/compatibility contract module so warning behavior
+stays readable. These tests must not contact the live MLB API.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import warnings
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+import mlbstatsapi
+from mlbstatsapi import (
+    Mlb,
+    MlbDataAdapter,
+    MlbDecodeError,
+    MlbHttpCompatibilityWarning,
+    MlbHttpError,
+    MlbTimeoutError,
+    MlbTransportError,
+)
+
+from http_contract_support import (
+    COMPATIBILITY_CLIENT_ERRORS,
+    HTTP_REASON_BY_STATUS,
+    NOT_FOUND_STATUS,
+    SERVER_ERRORS,
+)
+
+# Final 429 is retried first, so it is covered in tests/test_mlb_retries.py.
+WARNING_CLIENT_ERRORS = tuple(
+    code for code in COMPATIBILITY_CLIENT_ERRORS if code != 429
+)
+
+SPORTS_URL = "https://statsapi.mlb.com/api/v1/sports"
+
+
+def _response(
+    *,
+    status_code: int,
+    reason: str,
+    url: str,
+    content: bytes = b"",
+    payload=None,
+    text: str | None = None,
+):
+    """Build a fake requests Response for offline adapter tests."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.reason = reason
+    response.url = url
+    response.content = content
+    if text is not None:
+        response.text = text
+    elif content:
+        response.text = content.decode("utf-8", errors="replace")
+    else:
+        response.text = ""
+    if payload is None:
+        response.json.side_effect = ValueError("no json")
+    else:
+        response.json.return_value = payload
+    return response
+
+
+def _session_returning(response) -> MagicMock:
+    session = MagicMock()
+    session.get.return_value = response
+    return session
+
+
+def _session_for_status(
+    status_code: int,
+    *,
+    url: str = SPORTS_URL,
+    payload=None,
+) -> MagicMock:
+    content = b"" if payload is None else json.dumps(payload).encode("utf-8")
+    return _session_returning(
+        _response(
+            status_code=status_code,
+            reason=HTTP_REASON_BY_STATUS[status_code],
+            url=url,
+            content=content,
+            payload=payload,
+        )
+    )
+
+
+@contextlib.contextmanager
+def _recorded_compatibility_warnings():
+    """Record every MlbHttpCompatibilityWarning raised inside the block."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", MlbHttpCompatibilityWarning)
+        yield caught
+
+
+def _compatibility_warnings(caught) -> list:
+    return [
+        item
+        for item in caught
+        if issubclass(item.category, MlbHttpCompatibilityWarning)
+    ]
+
+
+# --- Public warning class ---
+
+
+def test_compatibility_warning_is_publicly_importable():
+    """The warning category is reachable from the package namespace."""
+    assert (
+        mlbstatsapi.MlbHttpCompatibilityWarning
+        is MlbHttpCompatibilityWarning
+    )
+
+
+def test_compatibility_warning_inherits_future_warning():
+    """FutureWarning keeps this migration notice visible by default."""
+    assert issubclass(MlbHttpCompatibilityWarning, FutureWarning)
+    assert issubclass(MlbHttpCompatibilityWarning, Warning)
+    assert not issubclass(MlbHttpCompatibilityWarning, DeprecationWarning)
+
+
+# --- Compatibility-mode non-404 4xx warns exactly once ---
+
+
+@pytest.mark.parametrize("status_code", WARNING_CLIENT_ERRORS)
+def test_compatibility_client_errors_warn_once_and_return_empty_result(status_code):
+    """Non-404 4xx warns once while preserving the historical empty result."""
+    session = _session_for_status(status_code)
+    adapter = MlbDataAdapter(session=session)
+
+    with pytest.warns(MlbHttpCompatibilityWarning) as warning_info:
+        result = adapter.get(endpoint="sports")
+
+    assert result.status_code == status_code
+    assert result.message == HTTP_REASON_BY_STATUS[status_code]
+    assert result.data == {}
+    assert len(warning_info) == 1
+
+
+@pytest.mark.parametrize("status_code", WARNING_CLIENT_ERRORS)
+def test_compatibility_warning_message_contains_migration_guidance(status_code):
+    """The message carries status, URL, mode, migration, and version guidance."""
+    session = _session_for_status(status_code)
+    adapter = MlbDataAdapter(session=session)
+
+    with pytest.warns(MlbHttpCompatibilityWarning) as warning_info:
+        adapter.get(endpoint="sports")
+
+    message = str(warning_info[0].message)
+    assert str(status_code) in message
+    assert SPORTS_URL in message
+    assert "compatibility mode" in message
+    assert "strict_http=True" in message
+    assert "MlbHttpError" in message
+    assert "version 1.0" in message
+
+
+def test_compatibility_warning_excludes_response_body():
+    """Response bodies must never leak into the warning message."""
+    payload = {"message": "secret client error detail"}
+    session = _session_for_status(403, payload=payload)
+    adapter = MlbDataAdapter(session=session)
+
+    with pytest.warns(MlbHttpCompatibilityWarning) as warning_info:
+        adapter.get(endpoint="sports")
+
+    message = str(warning_info[0].message)
+    assert "secret client error detail" not in message
+    assert json.dumps(payload) not in message
+
+
+def test_compatibility_warning_falls_back_to_request_url():
+    """A response without a URL still reports the requested endpoint."""
+    response = _response(
+        status_code=403,
+        reason=HTTP_REASON_BY_STATUS[403],
+        url=None,
+    )
+    adapter = MlbDataAdapter(session=_session_returning(response))
+
+    with pytest.warns(MlbHttpCompatibilityWarning) as warning_info:
+        adapter.get(endpoint="sports")
+
+    assert SPORTS_URL in str(warning_info[0].message)
+
+
+# --- Client wiring: default and explicit compatibility mode ---
+
+
+@pytest.mark.parametrize("status_code", WARNING_CLIENT_ERRORS)
+def test_default_mlb_client_warns_for_non_404_client_errors(status_code):
+    """Mlb() stays in compatibility mode and receives the migration notice."""
+    session = _session_for_status(status_code)
+    mlb = Mlb(session=session)
+
+    with pytest.warns(MlbHttpCompatibilityWarning) as warning_info:
+        result = mlb._mlb_adapter_v1.get(endpoint="sports")
+
+    assert result.status_code == status_code
+    assert result.data == {}
+    assert len(warning_info) == 1
+
+
+def test_default_mlb_client_public_endpoint_warns_and_keeps_return_shape():
+    """A public endpoint keeps returning None for 4xx while warning once."""
+    session = _session_for_status(
+        403,
+        url="https://statsapi.mlb.com/api/v1/people/664034",
+    )
+    mlb = Mlb(session=session)
+
+    with pytest.warns(MlbHttpCompatibilityWarning) as warning_info:
+        person = mlb.get_person(664034)
+
+    assert person is None
+    assert len(warning_info) == 1
+
+
+@pytest.mark.parametrize("status_code", WARNING_CLIENT_ERRORS)
+def test_explicit_compatibility_mode_warns_and_preserves_result(status_code):
+    """Mlb(strict_http=False) warns without changing the compatibility result."""
+    session = _session_for_status(status_code)
+    mlb = Mlb(session=session, strict_http=False)
+
+    with pytest.warns(MlbHttpCompatibilityWarning) as warning_info:
+        result = mlb._mlb_adapter_v1.get(endpoint="sports")
+
+    assert result.status_code == status_code
+    assert result.message == HTTP_REASON_BY_STATUS[status_code]
+    assert result.data == {}
+    assert len(warning_info) == 1
+
+
+# --- Strict mode raises instead of warning ---
+
+
+@pytest.mark.parametrize("status_code", WARNING_CLIENT_ERRORS)
+def test_strict_mode_raises_without_compatibility_warning(status_code):
+    """Strict mode raises MlbHttpError and emits no compatibility warning."""
+    payload = {"error": HTTP_REASON_BY_STATUS[status_code]}
+    session = _session_for_status(status_code, payload=payload)
+    mlb = Mlb(session=session, strict_http=True)
+
+    with _recorded_compatibility_warnings() as caught:
+        with pytest.raises(MlbHttpError) as exc_info:
+            mlb._mlb_adapter_v1.get(endpoint="sports")
+
+    exc = exc_info.value
+    assert exc.status_code == status_code
+    assert exc.reason == HTTP_REASON_BY_STATUS[status_code]
+    assert exc.url == SPORTS_URL
+    assert exc.method == "GET"
+    assert exc.response_data == payload
+    assert _compatibility_warnings(caught) == []
+
+
+# --- 404 stays warning-free in both modes ---
+
+
+@pytest.mark.parametrize("strict_http", [False, True])
+def test_adapter_404_does_not_warn(strict_http):
+    """A final 404 returns an MlbResult without warning in either mode."""
+    session = _session_for_status(
+        NOT_FOUND_STATUS,
+        url="https://statsapi.mlb.com/api/v1/people/999999",
+    )
+    adapter = MlbDataAdapter(session=session, strict_http=strict_http)
+
+    with _recorded_compatibility_warnings() as caught:
+        result = adapter.get(endpoint="people/999999")
+
+    assert result.status_code == NOT_FOUND_STATUS
+    assert result.data == {}
+    assert _compatibility_warnings(caught) == []
+
+
+@pytest.mark.parametrize("strict_http", [False, True])
+def test_public_404_return_shapes_do_not_warn(strict_http):
+    """404 keeps None / [] / {} endpoint shapes without emitting a warning."""
+    session = _session_for_status(
+        NOT_FOUND_STATUS,
+        url="https://statsapi.mlb.com/api/v1/people/999999",
+    )
+    mlb = Mlb(session=session, strict_http=strict_http)
+
+    with _recorded_compatibility_warnings() as caught:
+        assert mlb.get_person(999999) is None
+        assert mlb.get_teams() == []
+        assert mlb.get_player_stats(999999, ["season"], ["hitting"]) == {}
+
+    assert _compatibility_warnings(caught) == []
+
+
+# --- Successful responses stay warning-free ---
+
+
+@pytest.mark.parametrize("strict_http", [False, True])
+def test_successful_response_does_not_warn(strict_http):
+    """A 200 response parses normally and emits no compatibility warning."""
+    payload = {"sports": [{"id": 1}]}
+    session = _session_returning(
+        _response(
+            status_code=200,
+            reason="OK",
+            url=SPORTS_URL,
+            content=json.dumps(payload).encode("utf-8"),
+            payload=payload,
+        )
+    )
+    adapter = MlbDataAdapter(session=session, strict_http=strict_http)
+
+    with _recorded_compatibility_warnings() as caught:
+        result = adapter.get(endpoint="sports")
+
+    assert result.status_code == 200
+    assert result.data == payload
+    assert _compatibility_warnings(caught) == []
+
+
+# --- Final 5xx already raises, so it is not compatibility-suppressed ---
+
+
+@pytest.mark.parametrize("status_code", SERVER_ERRORS)
+@pytest.mark.parametrize("strict_http", [False, True])
+def test_final_server_errors_do_not_warn(status_code, strict_http):
+    """Final 5xx raises MlbHttpError in both modes without a compatibility warning."""
+    session = _session_for_status(status_code)
+    adapter = MlbDataAdapter(session=session, strict_http=strict_http)
+
+    with _recorded_compatibility_warnings() as caught:
+        with pytest.raises(MlbHttpError) as exc_info:
+            adapter.get(endpoint="sports")
+
+    assert exc_info.value.status_code == status_code
+    assert _compatibility_warnings(caught) == []
+
+
+# --- Transport, timeout, and decode failures stay warning-free ---
+
+
+@pytest.mark.parametrize("strict_http", [False, True])
+def test_timeout_does_not_warn(strict_http):
+    """Timeouts raise MlbTimeoutError without a compatibility warning."""
+    session = MagicMock()
+    session.get.side_effect = requests.exceptions.Timeout("timed out")
+    adapter = MlbDataAdapter(session=session, strict_http=strict_http)
+
+    with _recorded_compatibility_warnings() as caught:
+        with pytest.raises(MlbTimeoutError):
+            adapter.get(endpoint="sports")
+
+    assert _compatibility_warnings(caught) == []
+
+
+@pytest.mark.parametrize("strict_http", [False, True])
+def test_connection_failure_does_not_warn(strict_http):
+    """Connection failures raise MlbTransportError without a compatibility warning."""
+    session = MagicMock()
+    session.get.side_effect = requests.exceptions.ConnectionError("refused")
+    adapter = MlbDataAdapter(session=session, strict_http=strict_http)
+
+    with _recorded_compatibility_warnings() as caught:
+        with pytest.raises(MlbTransportError):
+            adapter.get(endpoint="sports")
+
+    assert _compatibility_warnings(caught) == []
+
+
+@pytest.mark.parametrize("strict_http", [False, True])
+def test_decode_failure_does_not_warn(strict_http):
+    """Malformed JSON on a 200 raises MlbDecodeError without warning."""
+    response = _response(
+        status_code=200,
+        reason="OK",
+        url=SPORTS_URL,
+        content=b'{"bad": json',
+        text='{"bad": json',
+    )
+    response.json.side_effect = ValueError("Expecting value")
+    adapter = MlbDataAdapter(
+        session=_session_returning(response),
+        strict_http=strict_http,
+    )
+
+    with _recorded_compatibility_warnings() as caught:
+        with pytest.raises(MlbDecodeError):
+            adapter.get(endpoint="sports")
+
+    assert _compatibility_warnings(caught) == []
+
+
+# --- Caller-controlled warning filters ---
+
+
+def test_caller_can_turn_the_warning_into_an_exception():
+    """A caller may promote only this category to an error."""
+    session = _session_for_status(403)
+    adapter = MlbDataAdapter(session=session)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", MlbHttpCompatibilityWarning)
+        with pytest.raises(MlbHttpCompatibilityWarning):
+            adapter.get(endpoint="sports")
+
+
+def test_caller_can_ignore_only_this_warning_category():
+    """Ignoring the category keeps the historical compatibility result."""
+    session = _session_for_status(403)
+    adapter = MlbDataAdapter(session=session)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        warnings.simplefilter("ignore", MlbHttpCompatibilityWarning)
+        result = adapter.get(endpoint="sports")
+
+    assert result.status_code == 403
+    assert result.data == {}
+    assert _compatibility_warnings(caught) == []
+
+
+def test_each_request_emits_its_own_warning():
+    """Every final non-404 4xx warns; deduplication is left to warning filters."""
+    session = _session_for_status(429)
+    adapter = MlbDataAdapter(session=session)
+
+    with _recorded_compatibility_warnings() as caught:
+        adapter.get(endpoint="sports")
+        adapter.get(endpoint="sports")
+
+    assert len(_compatibility_warnings(caught)) == 2

--- a/tests/test_mlb_retries.py
+++ b/tests/test_mlb_retries.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import threading
+import warnings
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Iterable
 
@@ -13,7 +14,14 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 import mlbstatsapi
-from mlbstatsapi import Mlb, MlbDataAdapter, MlbHttpError, MlbResult, create_retry_policy
+from mlbstatsapi import (
+    Mlb,
+    MlbDataAdapter,
+    MlbHttpCompatibilityWarning,
+    MlbHttpError,
+    MlbResult,
+    create_retry_policy,
+)
 
 from http_contract_support import (
     NON_RETRYABLE_CLIENT_ERRORS,
@@ -295,6 +303,37 @@ def test_final_429_returns_empty_mlb_result(
     assert result.status_code == 429
     assert result.data == {}
     assert _ScriptedHandler.request_count == 4
+
+
+def test_final_429_warns_once_after_retry_exhaustion(
+    scripted_http_server,
+    no_retry_sleep,
+):
+    """Compatibility mode warns only after the final 429, not per retry attempt."""
+    configure, port = scripted_http_server
+    configure([429, 429, 429, 429, 429, 429])
+    # Library-created Session keeps the mounted retry adapter; do not inject a mock.
+    adapter = _adapter_against_local_server(port)
+
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", MlbHttpCompatibilityWarning)
+            result = adapter.get(endpoint="sports")
+    finally:
+        adapter.close()
+
+    compatibility_warnings = [
+        item
+        for item in caught
+        if issubclass(item.category, MlbHttpCompatibilityWarning)
+    ]
+
+    assert _ScriptedHandler.request_count == 4
+    assert len(compatibility_warnings) == 1
+    assert "429" in str(compatibility_warnings[0].message)
+    assert isinstance(result, MlbResult)
+    assert result.status_code == 429
+    assert result.data == {}
 
 
 def test_final_429_raises_mlb_http_error_in_strict_mode(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #270
Refs #265

## Summary

* adds the public `MlbHttpCompatibilityWarning` category
* warns when compatibility mode suppresses a final non-404 4xx error
* preserves the historical compatibility result
* provides migration guidance for `strict_http=True`
* keeps 404, strict mode, successful responses, and unrelated failures warning-free
* emits final-429 warnings only after retries are exhausted

## Why

Issue #269 added opt-in `strict_http=True`. Compatibility mode remains the default, so
callers currently receive an empty `MlbResult` for a final non-404 4xx with no signal that
an error was suppressed. This adds a visible, filterable migration notice ahead of any
stricter default in version 1.0.

## What changed

* `mlbstatsapi/warnings.py`: new `MlbHttpCompatibilityWarning(FutureWarning)`.
  `FutureWarning` is used rather than `DeprecationWarning` so the notice stays visible
  under default filters.
* `mlbstatsapi/__init__.py`: exports the warning class.
* `mlbstatsapi/mlb_dataadapter.py`: the compatibility branch of the existing 4xx handling
  calls a small `_warn_http_compatibility()` helper before returning the historical empty
  `MlbResult`. The message includes only the status code and `response.url or full_url`,
  plus migration guidance. Strict mode still raises first, and 404 is skipped.
* `docs/http-transport.md`: new "Compatibility warnings" section covering when the warning
  fires, how to enable strict mode, and how to filter or promote only this category.
* `tests/test_http_warnings.py`: new focused offline module.
* `tests/test_mlb_retries.py`: final-429 retry-order test reusing the existing scripted
  local HTTP server.

Strict mode, retry policy, `MlbHttpError`, session ownership, timeouts, and endpoint
return types are unchanged. `tests/test_http_contract.py` needed no adjustment.

## How it was tested

* `poetry run pytest tests/test_http_warnings.py -v` (53 passed)
* `poetry run pytest tests/test_mlb_retries.py -v` (29 passed)
* `poetry run pytest tests/test_http_contract.py -v`
* `poetry run pytest tests/test_mlb_exceptions.py -v`
* `poetry run pytest tests/test_mlb_session.py -v`
* `poetry run pytest tests/ --ignore=tests/external_tests -v` (298 passed)
* `poetry run pytest tests/external_tests/ -v` (119 passed, 1 skipped)
* `git diff --check`

Coverage includes the public import and `FutureWarning` inheritance, a 400/401/403/405/422
matrix asserting one warning plus the preserved empty result, message-content assertions
(status, URL, `compatibility mode`, `strict_http=True`, `MlbHttpError`, `version 1.0`)
without freezing the full string, default `Mlb()` and explicit `strict_http=False`,
strict mode raising without warning, 404 in both modes including `get_person` / `get_teams`
/ `get_player_stats` shapes, successful responses, final 5xx, timeout / transport / decode
failures, warning-as-error and ignore filters, and the final-429 case asserting 4 requests
and exactly 1 warning.

## Risk level

Low. Behavior is additive: no return value, exception, or retry behavior changes. The main
visible effect is that applications running in compatibility mode against a non-404 4xx now
see a `FutureWarning` on stderr.

## Possible impact

Projects that run their test suites with `-W error` or `filterwarnings = error` may start
failing on suppressed non-404 4xx responses. That is the intended signal, and the warning
can be silenced by class or resolved by adopting `strict_http=True`.

## What was intentionally left out

* Making strict mode the default
* Any change to 404, 5xx, retry, session, or exception behavior
* A custom global warning registry or deduplication; standard Python warning filters
  decide display frequency
* Frame inspection for `stacklevel`; a fixed `stacklevel=3` points at the caller of
  `MlbDataAdapter.get()`

## Base branch

`release/0.9.0`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc963-271b-7b1a-bbdc-95f94a766a7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc963-271b-7b1a-bbdc-95f94a766a7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

