### PR TITLE
Add a versioned User-Agent

### DIFF
--- a/docs/http-transport.md
+++ b/docs/http-transport.md
@@ -136,6 +136,54 @@ The library does not install or replace retry adapters on caller-injected Sessio
 
 Callers who inject a Session control its retry, TLS, proxy, and adapter configuration.
 
+## User-Agent
+
+Library-created Sessions send a package-specific User-Agent:
+
+```text
+python-mlb-statsapi/<installed-version>
+```
+
+The version comes from the installed package metadata, so it always matches the
+installed release without a separately maintained version string.
+
+Notes:
+
+* The header helps identify package traffic while debugging
+* Other Requests default headers such as `Accept-Encoding`, `Accept`, and `Connection` remain intact
+* Only `User-Agent` is set; the full header mapping is never replaced
+* Caller-injected Sessions are never modified
+* Applications using an injected Session may set their own User-Agent
+* The header contains no machine identifiers, installation identifiers, hostnames, or user tracking data
+* This is not telemetry and sends no analytics
+
+If the distribution metadata is unavailable, for example in an unusual
+source-only environment, the header falls back to:
+
+```text
+python-mlb-statsapi/unknown
+```
+
+Callers who inject a Session control the User-Agent themselves:
+
+```python
+import requests
+import mlbstatsapi
+
+session = requests.Session()
+session.headers.update(
+    {
+        "User-Agent": "my-baseball-project/1.0",
+    }
+)
+
+try:
+    with mlbstatsapi.Mlb(session=session) as mlb:
+        player = mlb.get_person(664034)
+finally:
+    session.close()
+```
+
 ## Default retry policy
 
 Library-created Sessions mount a bounded retry policy for GET requests automatically.

--- a/mlbstatsapi/mlb_api.py
+++ b/mlbstatsapi/mlb_api.py
@@ -26,7 +26,7 @@ from .mlb_dataadapter import (
     DEFAULT_TIMEOUT,
     MlbDataAdapter,
     TimeoutType,
-    _configure_retry_adapters,
+    _configure_library_session,
 )
 # from .exceptions import TheMlbStatsApiException
 from . import mlb_module
@@ -56,11 +56,12 @@ class Mlb:
     ):
         # One session is shared by the v1 and v1.1 adapters. The library closes
         # only sessions it creates; caller-injected sessions remain caller-owned.
-        # Retry adapters are installed only on library-created Sessions.
+        # The versioned User-Agent and retry adapters are applied only to
+        # library-created Sessions.
         self._owns_session = session is None
         if session is None:
             self._session = requests.Session()
-            _configure_retry_adapters(self._session)
+            _configure_library_session(self._session)
         else:
             self._session = session
         self._closed = False

--- a/mlbstatsapi/mlb_dataadapter.py
+++ b/mlbstatsapi/mlb_dataadapter.py
@@ -1,3 +1,4 @@
+from importlib.metadata import PackageNotFoundError, version as package_version
 from typing import Dict
 
 from .exceptions import (
@@ -16,6 +17,11 @@ from urllib3.util.retry import Retry
 # Connect timeout, then read timeout. Callers may override with a scalar or tuple.
 DEFAULT_TIMEOUT = (3.05, 30.0)
 TimeoutType = int | float | tuple[float, float]
+
+# Distribution name published on PyPI; the User-Agent version is read from its
+# installed metadata so no release version is duplicated in source.
+PACKAGE_DISTRIBUTION_NAME = "python-mlb-statsapi"
+UNKNOWN_PACKAGE_VERSION = "unknown"
 
 # Bounded excerpt for error response bodies attached to MlbHttpError.
 HTTP_ERROR_BODY_EXCERPT_LIMIT = 500
@@ -135,6 +141,34 @@ def _configure_retry_adapters(
     )
 
 
+def _build_user_agent() -> str:
+    """Build the package User-Agent from installed distribution metadata.
+
+    Falls back to an "unknown" version for source-only environments where the
+    distribution metadata is not installed. This must never raise, because it
+    runs while a library-created Session is being constructed.
+    """
+    try:
+        installed_version = package_version(PACKAGE_DISTRIBUTION_NAME)
+    except PackageNotFoundError:
+        installed_version = UNKNOWN_PACKAGE_VERSION
+    return f"{PACKAGE_DISTRIBUTION_NAME}/{installed_version}"
+
+
+def _configure_library_session(
+    session: requests.Session,
+) -> None:
+    """Apply library defaults to a Session the library created and owns.
+
+    Caller-injected Sessions must not be passed here; their headers and
+    adapters stay under the caller's control.
+    """
+    # Only the User-Agent is replaced so the remaining Requests default
+    # headers (Accept-Encoding, Accept, Connection) are preserved.
+    session.headers["User-Agent"] = _build_user_agent()
+    _configure_retry_adapters(session)
+
+
 class MlbResult:
     """
     A class that holds data, status_code, and message returned from statsapi.mlb.com
@@ -194,7 +228,7 @@ class MlbDataAdapter:
         self._owns_session = session is None
         if session is None:
             self._session = requests.Session()
-            _configure_retry_adapters(self._session)
+            _configure_library_session(self._session)
         else:
             self._session = session
         self._closed = False

--- a/tests/test_mlb_session.py
+++ b/tests/test_mlb_session.py
@@ -1,16 +1,27 @@
-"""Offline tests for shared HTTP sessions and configurable timeouts.
+"""Offline tests for shared HTTP sessions, timeouts, and the package User-Agent.
 
-These tests cover session injection, ownership, cleanup, sharing, and timeout
-forwarding without calling the live MLB API.
+These tests cover session injection, ownership, cleanup, sharing, header
+handling, and timeout forwarding without calling the live MLB API.
 """
 
+from importlib.metadata import PackageNotFoundError
 from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
 
 from mlbstatsapi import Mlb, MlbDataAdapter, MlbHttpError, TheMlbStatsApiException
-from mlbstatsapi.mlb_dataadapter import DEFAULT_TIMEOUT
+from mlbstatsapi.mlb_dataadapter import (
+    DEFAULT_TIMEOUT,
+    PACKAGE_DISTRIBUTION_NAME,
+    _configure_library_session,
+)
+
+from http_contract_support import assert_library_retry_policy
+
+
+MOCKED_PACKAGE_VERSION = "9.8.7"
+MOCKED_USER_AGENT = f"python-mlb-statsapi/{MOCKED_PACKAGE_VERSION}"
 
 
 class RecordingSession:
@@ -436,3 +447,178 @@ def test_adapter_positional_hostname_version_and_logger():
     adapter = MlbDataAdapter("statsapi.mlb.com", "v1.1", logger)
     assert adapter._logger is logger
     adapter.close()
+
+
+# --- Versioned User-Agent ---
+
+
+@pytest.fixture
+def mocked_package_version():
+    """Patch the metadata lookup the production User-Agent helper uses."""
+    with patch(
+        "mlbstatsapi.mlb_dataadapter.package_version",
+        return_value=MOCKED_PACKAGE_VERSION,
+    ) as lookup:
+        yield lookup
+
+
+def test_user_agent_version_comes_from_package_metadata(mocked_package_version):
+    """The User-Agent version is read from installed distribution metadata."""
+    session = requests.Session()
+    try:
+        _configure_library_session(session)
+
+        assert session.headers["User-Agent"] == MOCKED_USER_AGENT
+    finally:
+        session.close()
+
+    mocked_package_version.assert_called_with(PACKAGE_DISTRIBUTION_NAME)
+
+
+def test_mlb_library_created_session_has_versioned_user_agent(mocked_package_version):
+    """Library-created Mlb Sessions send the package and version User-Agent."""
+    mlb = Mlb()
+    try:
+        user_agent = mlb._session.headers["User-Agent"]
+
+        assert "python-mlb-statsapi" in user_agent
+        assert user_agent == MOCKED_USER_AGENT
+    finally:
+        mlb.close()
+
+
+def test_standalone_adapter_session_has_versioned_user_agent(mocked_package_version):
+    """Library-created standalone adapter Sessions use the same User-Agent."""
+    adapter = MlbDataAdapter()
+    try:
+        assert adapter._session.headers["User-Agent"] == MOCKED_USER_AGENT
+    finally:
+        adapter.close()
+
+
+def test_prepared_request_carries_versioned_user_agent(mocked_package_version):
+    """The versioned User-Agent reaches the outgoing prepared request."""
+    mlb = Mlb()
+    try:
+        prepared = mlb._session.prepare_request(
+            requests.Request("GET", "https://example.test"),
+        )
+
+        assert prepared.headers["User-Agent"] == MOCKED_USER_AGENT
+    finally:
+        mlb.close()
+
+
+def test_library_created_session_preserves_requests_default_headers():
+    """Only User-Agent changes; other Requests default headers are untouched."""
+    baseline = requests.Session()
+    mlb = Mlb()
+    try:
+        for header, value in baseline.headers.items():
+            if header.lower() == "user-agent":
+                continue
+            assert mlb._session.headers[header] == value
+
+        for header in ("Accept-Encoding", "Accept", "Connection"):
+            assert mlb._session.headers[header] == baseline.headers[header]
+
+        assert mlb._session.headers["User-Agent"] != baseline.headers["User-Agent"]
+    finally:
+        mlb.close()
+        baseline.close()
+
+
+def test_injected_session_user_agent_is_preserved():
+    """A caller-provided User-Agent is never overwritten by the library."""
+    session = requests.Session()
+    session.headers["User-Agent"] = "my-baseball-project/1.0"
+
+    mlb = Mlb(session=session)
+    try:
+        assert session.headers["User-Agent"] == "my-baseball-project/1.0"
+        assert mlb._session.headers["User-Agent"] == "my-baseball-project/1.0"
+    finally:
+        mlb.close()
+
+    assert session.headers["User-Agent"] == "my-baseball-project/1.0"
+    session.close()
+
+
+def test_injected_session_custom_headers_are_preserved():
+    """Custom headers on an injected Session survive construction and close()."""
+    session = requests.Session()
+    session.headers.update(
+        {
+            "User-Agent": "my-baseball-project/1.0",
+            "X-Application": "scoreboard",
+        }
+    )
+    headers_before = dict(session.headers)
+
+    mlb = Mlb(session=session)
+    mlb.close()
+
+    assert dict(session.headers) == headers_before
+    assert session.headers["User-Agent"] == "my-baseball-project/1.0"
+    assert session.headers["X-Application"] == "scoreboard"
+    session.close()
+
+
+def test_standalone_adapter_injected_session_headers_are_preserved():
+    """A Session injected into MlbDataAdapter keeps all caller headers."""
+    session = requests.Session()
+    session.headers.update(
+        {
+            "User-Agent": "my-baseball-project/1.0",
+            "X-Application": "scoreboard",
+        }
+    )
+    headers_before = dict(session.headers)
+
+    adapter = MlbDataAdapter(session=session)
+    try:
+        assert dict(session.headers) == headers_before
+        assert session.headers["User-Agent"] == "my-baseball-project/1.0"
+        assert session.headers["X-Application"] == "scoreboard"
+    finally:
+        adapter.close()
+        session.close()
+
+
+def test_user_agent_falls_back_when_package_metadata_is_missing():
+    """Missing distribution metadata yields a safe value instead of raising."""
+    with patch(
+        "mlbstatsapi.mlb_dataadapter.package_version",
+        side_effect=PackageNotFoundError(PACKAGE_DISTRIBUTION_NAME),
+    ):
+        session = requests.Session()
+        try:
+            _configure_library_session(session)
+
+            assert session.headers["User-Agent"] == "python-mlb-statsapi/unknown"
+        finally:
+            session.close()
+
+
+def test_mlb_construction_succeeds_without_package_metadata():
+    """Client construction still works in source-only environments."""
+    with patch(
+        "mlbstatsapi.mlb_dataadapter.package_version",
+        side_effect=PackageNotFoundError(PACKAGE_DISTRIBUTION_NAME),
+    ):
+        mlb = Mlb()
+        try:
+            assert mlb._session.headers["User-Agent"] == "python-mlb-statsapi/unknown"
+        finally:
+            mlb.close()
+
+
+def test_user_agent_does_not_change_library_retry_adapters(mocked_package_version):
+    """Setting the User-Agent leaves the mounted retry adapters intact."""
+    mlb = Mlb()
+    try:
+        assert mlb._session.headers["User-Agent"] == MOCKED_USER_AGENT
+        assert_library_retry_policy(mlb._session.get_adapter("https://").max_retries)
+        assert_library_retry_policy(mlb._session.get_adapter("http://").max_retries)
+    finally:
+        mlb.close()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #271
Refs #265

## Summary

* adds a package and version User-Agent to library-created Sessions
* reads the installed version from package metadata
* preserves other Requests default headers
* leaves all caller-injected Session headers untouched
* preserves retry, strict-mode, and Session ownership behavior
* adds offline coverage for outgoing prepared requests

## Why

Requests sends its generic `python-requests/<version>` User-Agent by default, so MLB Stats API traffic from this package is indistinguishable from any other Requests-based client. A package-specific, versioned User-Agent makes package traffic identifiable while debugging and makes the installed release visible without any extra request data.

## What changed

`mlbstatsapi/mlb_dataadapter.py` gains one internal source of truth for library-owned Session setup:

* `PACKAGE_DISTRIBUTION_NAME = "python-mlb-statsapi"` is the only place the distribution name is stored.
* `_build_user_agent()` reads the version through `importlib.metadata.version()` and falls back to `unknown` on `PackageNotFoundError`, so it cannot raise during Session construction.
* `_configure_library_session()` sets `session.headers["User-Agent"]` and then calls the existing `_configure_retry_adapters()`.

`MlbDataAdapter.__init__` and `Mlb.__init__` now call `_configure_library_session()` in the branch that already handled `session is None`. Injected Sessions take exactly the same path as before and are never passed to the helper.

The package version is not duplicated in source. `pyproject.toml` is unchanged, and the header will automatically reflect the version bump made by the release-preparation issue. Nothing new is exported from `mlbstatsapi/__init__.py`.

## Behavior

| Session origin | User-Agent | Other headers | Adapters |
| -------------- | ---------- | ------------- | -------- |
| Library-created | `python-mlb-statsapi/<installed-version>` | Requests defaults preserved | Library retry policy |
| Caller-injected | Caller-controlled | Untouched | Caller-controlled |

Only the `User-Agent` key is assigned; the header mapping is never replaced, so `Accept-Encoding`, `Accept`, and `Connection` keep their Requests default values.

## Tests

New coverage in `tests/test_mlb_session.py`, all offline:

* the version comes from patched package metadata (`9.8.7` → `python-mlb-statsapi/9.8.7`), which proves no release string is hardcoded
* `Mlb()` and standalone `MlbDataAdapter()` Sessions both carry the versioned header
* a prepared request built with `session.prepare_request()` carries the header, with no request sent
* every non-`User-Agent` Requests default header matches a baseline `requests.Session()`, plus explicit checks for `Accept-Encoding`, `Accept`, and `Connection`
* an injected `my-baseball-project/1.0` User-Agent and an `X-Application: scoreboard` header stay unchanged through construction and `close()`, for both `Mlb` and `MlbDataAdapter`
* `PackageNotFoundError` yields `python-mlb-statsapi/unknown` and does not raise
* the mounted retry adapters still satisfy `assert_library_retry_policy()` after the header is set

The existing `test_injected_session_is_not_replaced_with_library_session` already asserts the Session identity contract across both adapters, so it was left as-is rather than duplicated.

## Documentation

`docs/http-transport.md` gains a `## User-Agent` section covering the header format, the metadata source, preserved default headers, the untouched injected-Session rule, the `unknown` fallback, an injected-Session example, and an explicit statement that this is not telemetry and carries no machine or user identifiers. The compatibility-warning documentation was not modified.

## Validation

* `poetry run pytest tests/test_mlb_session.py -v` — 45 passed
* `poetry run pytest tests/test_mlb_retries.py -v`
* `poetry run pytest tests/test_http_contract.py -v`
* `poetry run pytest tests/test_mlb_exceptions.py -v`
* `poetry run pytest tests/ --ignore=tests/external_tests -v` — 255 passed
* `git diff --check`

`tests/test_http_warnings.py` does not exist on `release/0.9.0` yet, so the issue #270 warning suite was not run here.

## Risk

Low. The only behavior change is one header value on Sessions the library creates itself. No public method, argument, return type, exception, or endpoint behavior changed, and no new runtime dependency was added (`importlib.metadata` is standard library).

Possible impact: any consumer asserting on the outgoing `User-Agent` of a library-created Session will now see `python-mlb-statsapi/<version>` instead of `python-requests/<version>`.

## Intentionally left out

* compatibility warnings and `MlbHttpCompatibilityWarning` work from #270, which this branch does not depend on
* the `pyproject.toml` version bump, which belongs to release preparation
* any machine identifiers, hostnames, OS or hardware details, request identifiers, application-name discovery, telemetry, or analytics
* exporting the internal User-Agent helper, since no new public API is required

## Base branch

`release/0.9.0`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc9d3-37f6-7d2f-9a13-fb22671503fc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc9d3-37f6-7d2f-9a13-fb22671503fc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

