### PR TITLE
feat: preserve explicit HTTP compatibility mode (#285)

### DIFF
--- a/mlbstatsapi/mlb_dataadapter.py
+++ b/mlbstatsapi/mlb_dataadapter.py
@@ -8,6 +8,7 @@ from .exceptions import (
     MlbTransportError,
 )
 from .warnings import MlbHttpCompatibilityWarning
+import inspect
 import logging
 import warnings
 
@@ -28,9 +29,33 @@ UNKNOWN_PACKAGE_VERSION = "unknown"
 # Bounded excerpt for error response bodies attached to MlbHttpError.
 HTTP_ERROR_BODY_EXCERPT_LIMIT = 500
 
-# Frames from warnings.warn() out to whoever called MlbDataAdapter.get(), so the
-# warning points at application code rather than the helper below.
-COMPATIBILITY_WARNING_STACKLEVEL = 3
+
+def _is_mlbstatsapi_module(module_name: str) -> bool:
+    """Return True when *module_name* belongs to this package."""
+    return module_name == "mlbstatsapi" or module_name.startswith("mlbstatsapi.")
+
+
+def _compatibility_warning_stacklevel() -> int:
+    """Return a warnings.warn stacklevel for the first non-package caller.
+
+    A fixed stack level cannot serve both direct MlbDataAdapter.get() calls and
+    public Mlb endpoint methods that wrap the adapter. Walk frames from the
+    caller of this helper outward and stop at the first module outside the
+    mlbstatsapi package namespace.
+    """
+    frame = inspect.currentframe()
+    stacklevel = 1
+    try:
+        frame = frame.f_back
+        while frame is not None:
+            module_name = frame.f_globals.get("__name__", "")
+            if not _is_mlbstatsapi_module(module_name):
+                return stacklevel
+            stacklevel += 1
+            frame = frame.f_back
+    finally:
+        del frame
+    return 1
 
 
 def _warn_http_compatibility(
@@ -45,13 +70,14 @@ def _warn_http_compatibility(
     """
     warnings.warn(
         (
-            f"HTTP {status_code} for {url} was handled through compatibility mode "
-            "and returned the historical empty result. Pass strict_http=True to "
-            "raise MlbHttpError. This compatibility behavior may change in "
-            "version 1.0."
+            f"HTTP {status_code} for {url} was suppressed because "
+            "strict_http=False explicitly selected compatibility mode, so the "
+            "historical empty result was returned. Strict HTTP behavior is the "
+            "default in version 1.0. Remove strict_http=False or pass "
+            "strict_http=True to raise MlbHttpError."
         ),
         MlbHttpCompatibilityWarning,
-        stacklevel=COMPATIBILITY_WARNING_STACKLEVEL,
+        stacklevel=_compatibility_warning_stacklevel(),
     )
 
 

--- a/tests/http_contract_support.py
+++ b/tests/http_contract_support.py
@@ -96,12 +96,6 @@ API_VERSIONS = ("v1", "v1.1")
 # Sentinel so helpers can omit strict_http and exercise the real constructor default.
 _UNSET = object()
 
-# Pending compatibility warning caller location via public Mlb endpoints (#285).
-XFAIL_PENDING_WARNING_CALL_SITE = pytest.mark.xfail(
-    strict=True,
-    reason="Pending #285: compatibility warning must point to the public caller",
-)
-
 
 def adapter_for_api_version(mlb, api_version: str):
     """Return the internal MlbDataAdapter for v1 or v1.1."""

--- a/tests/test_http_warnings.py
+++ b/tests/test_http_warnings.py
@@ -31,7 +31,6 @@ from http_contract_support import (
     HTTP_REASON_BY_STATUS,
     NOT_FOUND_STATUS,
     SERVER_ERRORS,
-    XFAIL_PENDING_WARNING_CALL_SITE,
     adapter_for_api_version,
     standalone_adapter_for_version,
 )
@@ -171,10 +170,11 @@ def test_compatibility_warning_message_contains_migration_guidance(status_code):
     message = str(warning_info[0].message)
     assert str(status_code) in message
     assert SPORTS_URL in message
+    assert "strict_http=False" in message
     assert "compatibility mode" in message
+    assert "default in version 1.0" in message
     assert "strict_http=True" in message
     assert "MlbHttpError" in message
-    assert "version 1.0" in message
 
 
 def test_compatibility_warning_excludes_response_body():
@@ -490,7 +490,6 @@ def test_compatibility_warning_points_to_direct_adapter_caller_line():
     assert warning.lineno == expected_lineno
 
 
-@XFAIL_PENDING_WARNING_CALL_SITE
 def test_compatibility_warning_points_to_public_mlb_endpoint_caller_line():
     """Public Mlb endpoint warnings must reference the application caller line."""
     import inspect


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #285

## Why compatibility mode remains available

Version 1.0 makes strict HTTP handling the default (#284), but callers who explicitly construct `Mlb(strict_http=False)` or `MlbDataAdapter(strict_http=False)` must keep the historical empty-result behavior for final non-404 4xx responses. This preserves an intentional opt-in escape hatch without changing the new default.

## Why the warning wording changed

The 0.9 wording said compatibility behavior “may change in version 1.0,” which is no longer accurate once 1.0 ships. The warning now states that:

- the caller explicitly selected compatibility mode with `strict_http=False`
- the historical empty result was returned
- strict HTTP behavior is the version 1.0 default
- removing `strict_http=False` or passing `strict_http=True` raises `MlbHttpError`

Only the status code and resolved request URL are included from the response. Response bodies, headers, credentials, cookies, and tokens are never included.

## Why a fixed stack level was insufficient

`COMPATIBILITY_WARNING_STACKLEVEL = 3` correctly pointed at direct `adapter.get()` callers, but for public `Mlb` endpoint methods the same fixed depth landed on the internal `mlbstatsapi/mlb_api.py` frame (for example `get_person` at line 178) instead of the application call site.

## How the external caller frame is selected

A private `_compatibility_warning_stacklevel()` helper walks `inspect.currentframe()` parents and returns the first `warnings.warn()` stack level whose module is outside the `mlbstatsapi` / `mlbstatsapi.*` namespace. This works for both direct adapter calls and public `Mlb` endpoint wrappers without hard-coding endpoint methods or relying on Python 3.12-only warning APIs.

## Confirmations

- Warning content excludes response bodies (covered by offline tests)
- Strict mode behavior and 404 empty-result shapes remain unchanged
- Constructor defaults remain `strict_http=True` after rebasing onto #284; this PR does not change defaults
- Retries, Sessions, User-Agent, version metadata, README, release notes, and CI were not changed

## #285 xfail removed

- Removed `XFAIL_PENDING_WARNING_CALL_SITE` from `tests/http_contract_support.py`
- Removed its import/use from `tests/test_http_warnings.py`
- `rg "XFAIL_PENDING_WARNING_CALL_SITE|Pending #285" tests` returns no matches

## Focused test results (after rebase onto #284)

```text
poetry run pytest \
  tests/test_http_warnings.py \
  tests/test_http_contract.py \
  tests/test_mlb_retries.py \
  tests/test_mlb_session.py \
  -v -rxX
```

**300 passed**, 0 failed, 0 xfailed

Caller-location tests:

- `test_compatibility_warning_points_to_direct_adapter_caller_line` — passed
- `test_compatibility_warning_points_to_public_mlb_endpoint_caller_line` — passed

## Full offline-suite results (after rebase)

```text
poetry run pytest tests/ --ignore=tests/external_tests -v -rxX
```

**433 passed**, 0 failed, 0 xfailed

## Remaining xfails and their issue numbers

None after rebasing onto merged #284. Previously pending `#284` xfails are gone from `release/1.0.0`.

## Rebase status relative to #284

Rebased onto `origin/release/1.0.0` after #291 (`feat: make strict HTTP behavior the default (#284)`) merged. Clean rebase with no conflicts. Production defaults remain:

```text
strict_http: bool = True  # mlb_api.py and mlb_dataadapter.py
```

Compatibility tests continue to use explicit `strict_http=False`.

## Risk assessment

**Low.** Changes are confined to compatibility-warning message text and stack-level calculation, plus activating the existing #285 contract test. Public return shapes, exception hierarchy, retry policy, Session ownership, and constructor defaults are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55209413-6a0c-4bad-8e4c-f5f746db489a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55209413-6a0c-4bad-8e4c-f5f746db489a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

