### PR TITLE
Feature/299 shared response parsers

### DIFF
--- a/mlbstatsapi/_parsers/people.py
+++ b/mlbstatsapi/_parsers/people.py
@@ -1,9 +1,15 @@
 from mlbstatsapi.models.people import Person
 
-def parse_people(data: dict) -> list[Person]:
-    """Parse a list of people from the data"""
-    return [Person(**person) for person in data['people']] if data['people'] else []
 
-def parse_person(data: dict) -> Person:
-    """Parse a person from the data"""
-    return Person(**data) if data else None
+def parse_people(data: dict) -> list[Person]:
+    """Parse Person models from an MLB /people response body."""
+    if not data or not data.get("people"):
+        return []
+    return [Person(**person) for person in data["people"]]
+
+
+def parse_person(data: dict) -> Person | None:
+    """Parse a Person from a single person payload."""
+    if not data:
+        return None
+    return Person(**data)

--- a/mlbstatsapi/_parsers/people.py
+++ b/mlbstatsapi/_parsers/people.py
@@ -10,6 +10,11 @@ def parse_people(data: dict) -> list[Person]:
 
 def parse_person(data: dict) -> Person | None:
     """Parse a Person from a single person payload."""
-    if not data:
+
+    people = parse_people(data)
+
+    if not people:
         return None
-    return Person(**data)
+
+    return people[0]
+

--- a/mlbstatsapi/_parsers/people.py
+++ b/mlbstatsapi/_parsers/people.py
@@ -1,0 +1,9 @@
+from mlbstatsapi.models.people import Person
+
+def parse_people(data: dict) -> list[Person]:
+    """Parse a list of people from the data"""
+    return [Person(**person) for person in data['people']] if data['people'] else []
+
+def parse_person(data: dict) -> Person:
+    """Parse a person from the data"""
+    return Person(**data) if data else None

--- a/mlbstatsapi/_parsers/schedules.py
+++ b/mlbstatsapi/_parsers/schedules.py
@@ -3,6 +3,7 @@ from mlbstatsapi.models.schedules import Schedule
 
 def parse_schedule(data: dict) -> Schedule | None:
     """Parse a Schedule from an MLB /schedule response body."""
-    if not data:
+    if not data or not data.get("dates"):
         return None
+
     return Schedule(**data)

--- a/mlbstatsapi/_parsers/schedules.py
+++ b/mlbstatsapi/_parsers/schedules.py
@@ -1,0 +1,9 @@
+from mlbstatsapi.models.schedules import Schedule
+
+def parse_schedules(data: dict) -> list[Schedule]:
+    """Parse a list of schedules from the data"""
+    return [Schedule(**schedule) for schedule in data['schedules']] if data['schedules'] else []
+
+def parse_schedule(data: dict) -> Schedule:
+    """Parse a schedule from the data"""
+    return Schedule(**data) if data else None

--- a/mlbstatsapi/_parsers/schedules.py
+++ b/mlbstatsapi/_parsers/schedules.py
@@ -1,9 +1,8 @@
 from mlbstatsapi.models.schedules import Schedule
 
-def parse_schedules(data: dict) -> list[Schedule]:
-    """Parse a list of schedules from the data"""
-    return [Schedule(**schedule) for schedule in data['schedules']] if data['schedules'] else []
 
-def parse_schedule(data: dict) -> Schedule:
-    """Parse a schedule from the data"""
-    return Schedule(**data) if data else None
+def parse_schedule(data: dict) -> Schedule | None:
+    """Parse a Schedule from an MLB /schedule response body."""
+    if not data:
+        return None
+    return Schedule(**data)

--- a/mlbstatsapi/_parsers/teams.py
+++ b/mlbstatsapi/_parsers/teams.py
@@ -13,6 +13,10 @@ def parse_teams(data: dict) -> list[Team]:
 
 def parse_team(data: dict) -> Team | None:
     """Parse a Team from a single team payload."""
-    if not data:
+    teams = parse_teams(data)
+
+    if not teams:
         return None
-    return Team(**data)
+
+    return teams[0]
+

--- a/mlbstatsapi/_parsers/teams.py
+++ b/mlbstatsapi/_parsers/teams.py
@@ -2,7 +2,10 @@ from mlbstatsapi.models.teams import Team
 
 
 def parse_teams(data: dict) -> list[Team]:
-    """Parse Team models from an MLB /teams response body."""
+    """Parse Team models from an MLB /teams response body.
+
+    Expects the full response, e.g. ``{"teams": [...]}``, not the inner list.
+    """
     if not data or not data.get("teams"):
         return []
     return [Team(**team) for team in data["teams"]]

--- a/mlbstatsapi/_parsers/teams.py
+++ b/mlbstatsapi/_parsers/teams.py
@@ -1,0 +1,15 @@
+from mlbstatsapi.models.teams import Team
+
+
+def parse_teams(data: dict) -> list[Team]:
+    """Parse Team models from an MLB /teams response body."""
+    if not data or not data.get("teams"):
+        return []
+    return [Team(**team) for team in data["teams"]]
+
+
+def parse_team(data: dict) -> Team | None:
+    """Parse a Team from a single team payload."""
+    if not data:
+        return None
+    return Team(**data)

--- a/mlbstatsapi/mlb_api.py
+++ b/mlbstatsapi/mlb_api.py
@@ -22,6 +22,11 @@ from mlbstatsapi.models.gamepace import GamePace
 from mlbstatsapi.models.homerunderby import HomeRunDerby
 from mlbstatsapi.models.standings import Standings
 
+
+from ._parsers.people import parse_people, parse_person
+from ._parsers.teams import parse_teams, parse_team
+from ._parsers.schedules import parse_schedule
+
 from .mlb_dataadapter import (
     DEFAULT_TIMEOUT,
     MlbDataAdapter,
@@ -145,7 +150,7 @@ class Mlb:
         people = []
 
         if 'people' in mlb_data.data and mlb_data.data['people']:
-            people = [Person(**person) for person in mlb_data.data['people']]
+            people = parse_people(mlb_data.data)
 
         return people
 
@@ -183,7 +188,10 @@ class Mlb:
 
         if 'people' in mlb_data.data and mlb_data.data['people']:
             for person in mlb_data.data['people']:
-                return Person(**person)
+                person = parse_person(person)
+                if person:
+                    return person
+        return None
 
     def get_persons(self, person_ids: Union[str, List[int]], **params) -> List[Person]:
         """
@@ -246,8 +254,7 @@ class Mlb:
         person_list = []
 
         if 'people' in mlb_data.data and mlb_data.data['people']:
-            for person in mlb_data.data['people']:
-                person_list.append(Person(**person))
+            person_list = parse_people(mlb_data.data)
 
         return person_list
 
@@ -382,7 +389,7 @@ class Mlb:
         teams = []
 
         if 'teams' in mlb_data.data and mlb_data.data['teams']:
-            teams = [Team(**team) for team in mlb_data.data['teams']]
+            teams = parse_teams(mlb_data.data)
 
         return teams
 
@@ -451,8 +458,8 @@ class Mlb:
             return None
 
         if 'teams' in mlb_data.data and mlb_data.data['teams']:
-            for team in mlb_data.data['teams']:
-                return Team(**team)
+            return parse_team(mlb_data.data['teams'][0])
+        return None
 
     def get_team_id(self, team_name: str,
                     search_key: str = 'name', **params) -> List[int]:
@@ -831,7 +838,8 @@ class Mlb:
         # Only check for existance 'dates' key for this reason.
 
         if 'dates' in mlb_data.data and mlb_data.data['dates']:
-            return Schedule(**mlb_data.data)
+            return parse_schedule(mlb_data.data)
+        return None
 
     def get_scheduled_games_by_date(self, date: str = None,
                                     start_date: str = None, 

--- a/mlbstatsapi/mlb_api.py
+++ b/mlbstatsapi/mlb_api.py
@@ -246,12 +246,7 @@ class Mlb:
         if 400 <= mlb_data.status_code <= 499:
             return []
 
-        person_list = []
-
-        if 'people' in mlb_data.data and mlb_data.data['people']:
-            person_list = parse_people(mlb_data.data)
-
-        return person_list
+        return parse_people(mlb_data.data)
 
     def get_people_id(self, fullname: str, sport_id: int = 1, 
                       search_key: str = 'fullName', **params) -> List[int]:
@@ -381,12 +376,8 @@ class Mlb:
         if 400 <= mlb_data.status_code <= 499:
             return []
 
-        teams = []
+        return parse_teams(mlb_data.data)
 
-        if 'teams' in mlb_data.data and mlb_data.data['teams']:
-            teams = parse_teams(mlb_data.data)
-
-        return teams
 
     def get_team(self, team_id: int, **params) -> Union[Team, None]:
         """

--- a/mlbstatsapi/mlb_api.py
+++ b/mlbstatsapi/mlb_api.py
@@ -187,11 +187,7 @@ class Mlb:
             return None
 
         if 'people' in mlb_data.data and mlb_data.data['people']:
-            for person in mlb_data.data['people']:
-                person = parse_person(person)
-                if person:
-                    return person
-        return None
+            return parse_person(mlb_data.data)
 
     def get_persons(self, person_ids: Union[str, List[int]], **params) -> List[Person]:
         """
@@ -457,9 +453,7 @@ class Mlb:
         if 400 <= mlb_data.status_code <= 499:
             return None
 
-        if 'teams' in mlb_data.data and mlb_data.data['teams']:
-            return parse_team(mlb_data.data['teams'][0])
-        return None
+        return parse_team(mlb_data.data)
 
     def get_team_id(self, team_name: str,
                     search_key: str = 'name', **params) -> List[int]:

--- a/mlbstatsapi/mlb_api.py
+++ b/mlbstatsapi/mlb_api.py
@@ -186,8 +186,7 @@ class Mlb:
         if 400 <= mlb_data.status_code <= 499:
             return None
 
-        if 'people' in mlb_data.data and mlb_data.data['people']:
-            return parse_person(mlb_data.data)
+        return parse_person(mlb_data.data)
 
     def get_persons(self, person_ids: Union[str, List[int]], **params) -> List[Person]:
         """
@@ -831,9 +830,7 @@ class Mlb:
         # can sometimes be an empty list when there are no scheduled game for the date(s).
         # Only check for existance 'dates' key for this reason.
 
-        if 'dates' in mlb_data.data and mlb_data.data['dates']:
-            return parse_schedule(mlb_data.data)
-        return None
+        return parse_schedule(mlb_data.data)
 
     def get_scheduled_games_by_date(self, date: str = None,
                                     start_date: str = None, 

--- a/tests/parsers/Untitled
+++ b/tests/parsers/Untitled
@@ -1,0 +1,2 @@
+    assert parse_teams({}) == []
+    assert parse_teams({"teams": []}) == []

--- a/tests/parsers/Untitled
+++ b/tests/parsers/Untitled
@@ -1,2 +1,0 @@
-    assert parse_teams({}) == []
-    assert parse_teams({"teams": []}) == []

--- a/tests/parsers/test_people.py
+++ b/tests/parsers/test_people.py
@@ -30,7 +30,7 @@ def test_parse_person():
     assert parse_person({}) is None
 
     person = parse_person(
-        {"id": 1, "link": "/api/v1/people/1", "fullName": "Person 1"}
+        {"people": [{"id": 1, "link": "/api/v1/people/1", "fullName": "Person 1"}]} 
     )
 
     assert isinstance(person, Person)
@@ -40,4 +40,4 @@ def test_parse_person():
 def test_parse_person_requires_link():
     """Person requires link, the same required field used by the MLB API."""
     with pytest.raises(ValidationError):
-        parse_person({"id": 1, "fullName": "Person 1"})
+        parse_person({"people": [{"id": 1, "fullName": "Person 1"}]})

--- a/tests/parsers/test_people.py
+++ b/tests/parsers/test_people.py
@@ -1,0 +1,38 @@
+import pytest
+from pydantic import ValidationError
+from mlbstatsapi._parsers.people import parse_people, parse_person
+from mlbstatsapi.models.people import Person
+
+
+def test_parse_people():
+    """Test the parse_people function"""
+    assert parse_people({}) == []
+    assert parse_people({"people": []}) == []
+
+    people = parse_people(
+        {
+            "people": [
+                {"id": 1, "name": "Person 1"},
+                {"id": 2, "name": "Person 2"},
+            ]
+        }
+    )
+
+    assert people == [
+        Person(id=1, name="Person 1"),
+        Person(id=2, name="Person 2"),
+    ]
+
+def test_parse_person():
+    """Test the parse_person function"""
+    assert parse_person({}) is None
+
+    person = parse_person({"id": 1, "name": "Person 1"})
+
+    assert isinstance(person, Person)
+    assert person == Person(id=1, name="Person 1")
+
+def test_parse_person_requires_name():
+    """Test the parse_person function requires name"""
+    with pytest.raises(ValidationError):
+        parse_person({"id": 1})

--- a/tests/parsers/test_people.py
+++ b/tests/parsers/test_people.py
@@ -1,38 +1,43 @@
 import pytest
 from pydantic import ValidationError
+
 from mlbstatsapi._parsers.people import parse_people, parse_person
 from mlbstatsapi.models.people import Person
 
 
 def test_parse_people():
-    """Test the parse_people function"""
+    """parse_people reads the MLB people envelope and returns Person models."""
     assert parse_people({}) == []
     assert parse_people({"people": []}) == []
 
     people = parse_people(
         {
             "people": [
-                {"id": 1, "name": "Person 1"},
-                {"id": 2, "name": "Person 2"},
+                {"id": 1, "link": "/api/v1/people/1", "fullName": "Person 1"},
+                {"id": 2, "link": "/api/v1/people/2", "fullName": "Person 2"},
             ]
         }
     )
 
     assert people == [
-        Person(id=1, name="Person 1"),
-        Person(id=2, name="Person 2"),
+        Person(id=1, link="/api/v1/people/1", full_name="Person 1"),
+        Person(id=2, link="/api/v1/people/2", full_name="Person 2"),
     ]
 
+
 def test_parse_person():
-    """Test the parse_person function"""
+    """parse_person builds a Person from one person payload."""
     assert parse_person({}) is None
 
-    person = parse_person({"id": 1, "name": "Person 1"})
+    person = parse_person(
+        {"id": 1, "link": "/api/v1/people/1", "fullName": "Person 1"}
+    )
 
     assert isinstance(person, Person)
-    assert person == Person(id=1, name="Person 1")
+    assert person == Person(id=1, link="/api/v1/people/1", full_name="Person 1")
 
-def test_parse_person_requires_name():
-    """Test the parse_person function requires name"""
+
+def test_parse_person_requires_link():
+    """Person requires link, the same required field used by the MLB API."""
     with pytest.raises(ValidationError):
-        parse_person({"id": 1})
+        parse_person({"id": 1, "fullName": "Person 1"})

--- a/tests/parsers/test_schedules.py
+++ b/tests/parsers/test_schedules.py
@@ -14,7 +14,16 @@ def test_parse_schedule():
         "totalEvents": 0,
         "totalGames": 1,
         "totalGamesInProgress": 0,
-        "dates": [],
+        "dates": [
+            {
+                "date": "2026-08-12",
+                "totalItems": 1,
+                "totalEvents": 0,
+                "totalGames": 1,
+                "totalGamesInProgress": 0,
+                "games": [],
+            }
+        ]
     }
     schedule = parse_schedule(payload)
 
@@ -25,4 +34,17 @@ def test_parse_schedule():
 def test_parse_schedule_requires_totals():
     """Schedule requires the MLB total* fields from the response body."""
     with pytest.raises(ValidationError):
-        parse_schedule({"dates": []})
+        parse_schedule(
+            {
+                "dates": [
+                    {
+                        "date": "2026-08-12",
+                        "totalItems": 0,
+                        "totalEvents": 0,
+                        "totalGames": 0,
+                        "totalGamesInProgress": 0,
+                        "games": [],
+                    }
+                ]
+            }
+        )

--- a/tests/parsers/test_schedules.py
+++ b/tests/parsers/test_schedules.py
@@ -1,37 +1,28 @@
 import pytest
 from pydantic import ValidationError
-from mlbstatsapi._parsers.schedules import parse_schedules, parse_schedule
+
+from mlbstatsapi._parsers.schedules import parse_schedule
 from mlbstatsapi.models.schedules import Schedule
 
-def test_parse_schedules():
-    """Test the parse_schedules function"""
-    assert parse_schedules({}) == []
-    assert parse_schedules({"schedules": []}) == []
-
-    schedules = parse_schedules(
-        {
-            "schedules": [
-                {"id": 1, "name": "Schedule 1"},
-                {"id": 2, "name": "Schedule 2"},
-            ]
-        }
-    )
-
-    assert schedules == [
-        Schedule(id=1, name="Schedule 1"),
-        Schedule(id=2, name="Schedule 2"),
-    ]
 
 def test_parse_schedule():
-    """Test the parse_schedule function"""
+    """parse_schedule builds a Schedule from the full MLB schedule body."""
     assert parse_schedule({}) is None
 
-    schedule = parse_schedule({"id": 1, "name": "Schedule 1"})
+    payload = {
+        "totalItems": 1,
+        "totalEvents": 0,
+        "totalGames": 1,
+        "totalGamesInProgress": 0,
+        "dates": [],
+    }
+    schedule = parse_schedule(payload)
 
     assert isinstance(schedule, Schedule)
-    assert schedule == Schedule(id=1, name="Schedule 1")
+    assert schedule == Schedule(**payload)
 
-def test_parse_schedule_requires_name():
-    """Test the parse_schedule function requires name"""
+
+def test_parse_schedule_requires_totals():
+    """Schedule requires the MLB total* fields from the response body."""
     with pytest.raises(ValidationError):
-        parse_schedule({"id": 1})
+        parse_schedule({"dates": []})

--- a/tests/parsers/test_schedules.py
+++ b/tests/parsers/test_schedules.py
@@ -1,0 +1,37 @@
+import pytest
+from pydantic import ValidationError
+from mlbstatsapi._parsers.schedules import parse_schedules, parse_schedule
+from mlbstatsapi.models.schedules import Schedule
+
+def test_parse_schedules():
+    """Test the parse_schedules function"""
+    assert parse_schedules({}) == []
+    assert parse_schedules({"schedules": []}) == []
+
+    schedules = parse_schedules(
+        {
+            "schedules": [
+                {"id": 1, "name": "Schedule 1"},
+                {"id": 2, "name": "Schedule 2"},
+            ]
+        }
+    )
+
+    assert schedules == [
+        Schedule(id=1, name="Schedule 1"),
+        Schedule(id=2, name="Schedule 2"),
+    ]
+
+def test_parse_schedule():
+    """Test the parse_schedule function"""
+    assert parse_schedule({}) is None
+
+    schedule = parse_schedule({"id": 1, "name": "Schedule 1"})
+
+    assert isinstance(schedule, Schedule)
+    assert schedule == Schedule(id=1, name="Schedule 1")
+
+def test_parse_schedule_requires_name():
+    """Test the parse_schedule function requires name"""
+    with pytest.raises(ValidationError):
+        parse_schedule({"id": 1})

--- a/tests/parsers/test_teams.py
+++ b/tests/parsers/test_teams.py
@@ -1,0 +1,41 @@
+import pytest
+from pydantic import ValidationError
+
+from mlbstatsapi._parsers.teams import parse_team, parse_teams
+from mlbstatsapi.models.teams import Team
+
+
+def test_parse_teams():
+    """parse_teams reads the MLB teams envelope and returns Team models."""
+    assert parse_teams({}) == []
+    assert parse_teams({"teams": []}) == []
+
+    teams = parse_teams(
+        {
+            "teams": [
+                {"id": 1, "link": "/api/v1/teams/1", "name": "Team 1"},
+                {"id": 2, "link": "/api/v1/teams/2", "name": "Team 2"},
+            ]
+        }
+    )
+
+    assert teams == [
+        Team(id=1, link="/api/v1/teams/1", name="Team 1"),
+        Team(id=2, link="/api/v1/teams/2", name="Team 2"),
+    ]
+
+
+def test_parse_team():
+    """parse_team builds a Team from one team payload."""
+    assert parse_team({}) is None
+
+    team = parse_team({"id": 1, "link": "/api/v1/teams/1", "name": "Team 1"})
+
+    assert isinstance(team, Team)
+    assert team == Team(id=1, link="/api/v1/teams/1", name="Team 1")
+
+
+def test_parse_team_requires_link():
+    """Team requires link, the same required field used by the MLB API."""
+    with pytest.raises(ValidationError):
+        parse_team({"id": 1, "name": "Team 1"})

--- a/tests/parsers/test_teams.py
+++ b/tests/parsers/test_teams.py
@@ -29,7 +29,7 @@ def test_parse_team():
     """parse_team builds a Team from one team payload."""
     assert parse_team({}) is None
 
-    team = parse_team({"id": 1, "link": "/api/v1/teams/1", "name": "Team 1"})
+    team = parse_team({"teams": [{"id": 1, "link": "/api/v1/teams/1", "name": "Team 1"}]})
 
     assert isinstance(team, Team)
     assert team == Team(id=1, link="/api/v1/teams/1", name="Team 1")
@@ -38,4 +38,4 @@ def test_parse_team():
 def test_parse_team_requires_link():
     """Team requires link, the same required field used by the MLB API."""
     with pytest.raises(ValidationError):
-        parse_team({"id": 1, "name": "Team 1"})
+        parse_team({"teams": [{"id": 1, "name": "Team 1"}]})


### PR DESCRIPTION
### Why

The upcoming async client needs to return the same existing domain models and preserve the same parsing behavior as the synchronous client.

Previously, response parsing and model construction lived directly inside `Mlb` endpoint methods. That would have forced us to duplicate the same logic in `AsyncMlb`.

This PR extracts the initial shared parsing layer for #299 so both sync and async clients can eventually use the same response-to-model path.

### What

- Added a private `mlbstatsapi._parsers` package
- Organized parsers by domain:
  - teams
  - people
  - schedules
- Added shared parsing helpers for the initial async vertical slice:
  - `parse_team`
  - `parse_teams`
  - `parse_person`
  - `parse_people`
  - `parse_schedule`
- Updated the existing synchronous `Mlb` methods to use the shared parsers
- Kept HTTP status handling and request logic outside the parser layer
- Preserved existing `None` and empty-list behavior
- Added focused unit tests for the new parser functions

The parser package remains private and transport-independent so it can be reused by the future async client without exposing new public API.

Closes #299

### Tests

Ran the full test suite:

```bash
pytest
```

All tests pass.

Added direct parser tests covering:

- Valid Team, Person, and Schedule responses
- Empty response/envelope behavior
- Required model field validation
- Singular and plural response parsing

### Risk and impact

**Minimal**

This is primarily an internal refactor. Existing public method signatures and return types are unchanged, and the synchronous client continues to use the same existing Pydantic models.

The main risk is accidentally changing how an MLB response is interpreted when moving model construction into the shared parser layer. The existing synchronous test suite and the new focused parser tests help protect against that.

If something does go wrong, the likely impact would be an affected endpoint returning `None`, an empty list, or raising a model validation error where it previously returned a populated domain model. The changes are limited to the Team, Person, and Schedule parsing paths introduced for the initial async vertical slice.